### PR TITLE
Add godot-mcp-docs submodule + workflow hygiene/docs updates

### DIFF
--- a/.github/actions/phoenix-cache-restore/action.yml
+++ b/.github/actions/phoenix-cache-restore/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: ${{ github.job }}
   cache-scope:
     description: Logical scope to avoid cache key collisions across workflows.
-    default: ${{ github.workflow_ref }}
+    default: ${{ github.workflow }}
   scons-cache:
     description: The SCons cache path.
     default: ${{ github.workspace }}/.scons_cache/
@@ -14,16 +14,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Compute cache tree hash
+      shell: sh
+      run: |
+        tree_hash="$(git rev-parse "${GITHUB_SHA}^{tree}" 2>/dev/null || git rev-parse HEAD^{tree})"
+        if [ -z "$tree_hash" ]; then
+          echo "Failed to compute git tree hash for cache key" >&2
+          exit 1
+        fi
+        echo "CACHE_TREE_HASH=$tree_hash" >> "$GITHUB_ENV"
+
     - name: Restore cache
       uses: actions/cache/restore@v4
       id: cache-ping
       with:
         path: ${{ inputs.scons-cache }}
-        key: ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ github.ref_name }}|${{ github.sha }}
-        restore-keys: |
-          ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ github.ref_name }}|
-          ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ github.event.repository.default_branch }}|
-          ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|
+        key: ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ env.CACHE_TREE_HASH }}
 
     - name: Store unix timestamp
       shell: sh

--- a/.github/actions/phoenix-cache-restore/action.yml
+++ b/.github/actions/phoenix-cache-restore/action.yml
@@ -14,22 +14,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Compute cache tree hash
-      shell: sh
-      run: |
-        tree_hash="$(git rev-parse "${GITHUB_SHA}^{tree}" 2>/dev/null || git rev-parse HEAD^{tree})"
-        if [ -z "$tree_hash" ]; then
-          echo "Failed to compute git tree hash for cache key" >&2
-          exit 1
-        fi
-        echo "CACHE_TREE_HASH=$tree_hash" >> "$GITHUB_ENV"
-
     - name: Restore cache
       uses: actions/cache/restore@v4
       id: cache-ping
       with:
         path: ${{ inputs.scons-cache }}
-        key: ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ env.CACHE_TREE_HASH }}
+        key: ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ github.ref_name }}|${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ github.ref_name }}|
 
     - name: Store unix timestamp
       shell: sh

--- a/.github/actions/phoenix-cache-save/action.yml
+++ b/.github/actions/phoenix-cache-save/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: ${{ github.job }}
   cache-scope:
     description: Logical scope to avoid cache key collisions across workflows.
-    default: ${{ github.workflow_ref }}
+    default: ${{ github.workflow }}
   scons-cache:
     description: The SCons cache path.
     default: ${{ github.workspace }}/.scons_cache/
@@ -14,6 +14,20 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Ensure cache tree hash
+      shell: sh
+      run: |
+        if [ -n "${CACHE_TREE_HASH:-}" ]; then
+          exit 0
+        fi
+
+        tree_hash="$(git rev-parse "${GITHUB_SHA}^{tree}" 2>/dev/null || git rev-parse HEAD^{tree})"
+        if [ -z "$tree_hash" ]; then
+          echo "Failed to compute git tree hash for cache key" >&2
+          exit 1
+        fi
+        echo "CACHE_TREE_HASH=$tree_hash" >> "$GITHUB_ENV"
+
     - name: Purge files before timestamp
       shell: sh
       run: misc/scripts/purge_cache.py ${{ env.CACHE_TIMESTAMP }} "${{ inputs.scons-cache }}"
@@ -22,4 +36,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ${{ inputs.scons-cache }}
-        key: ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ github.ref_name }}|${{ github.sha }}
+        key: ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ env.CACHE_TREE_HASH }}

--- a/.github/actions/phoenix-cache-save/action.yml
+++ b/.github/actions/phoenix-cache-save/action.yml
@@ -14,20 +14,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Ensure cache tree hash
-      shell: sh
-      run: |
-        if [ -n "${CACHE_TREE_HASH:-}" ]; then
-          exit 0
-        fi
-
-        tree_hash="$(git rev-parse "${GITHUB_SHA}^{tree}" 2>/dev/null || git rev-parse HEAD^{tree})"
-        if [ -z "$tree_hash" ]; then
-          echo "Failed to compute git tree hash for cache key" >&2
-          exit 1
-        fi
-        echo "CACHE_TREE_HASH=$tree_hash" >> "$GITHUB_ENV"
-
     - name: Purge files before timestamp
       shell: sh
       run: misc/scripts/purge_cache.py ${{ env.CACHE_TIMESTAMP }} "${{ inputs.scons-cache }}"
@@ -36,4 +22,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ${{ inputs.scons-cache }}
-        key: ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ env.CACHE_TREE_HASH }}
+        key: ${{ inputs.cache-name }}|${{ inputs.cache-scope }}|${{ github.ref_name }}|${{ github.sha }}

--- a/.github/context/CURRENT_TASK.md
+++ b/.github/context/CURRENT_TASK.md
@@ -1,0 +1,42 @@
+# Current Task — Phoenix Agentic Engine
+
+> **No active task.** Run the `focus` skill to pick the next task from the roadmap.
+
+## How this file works
+
+- This file is the **active task pointer** for this repo.
+- Agents MUST read this file at the start of every session.
+- When a task is active, this file contains: issue link, branch, status, key files, checkpoint, and next step.
+- When a task is complete, delete the task content and replace with the "no active task" header above.
+- To pick the next task, read the roadmap and project board, then fill in the template below.
+
+## Template (fill in when starting a task)
+
+```markdown
+# Current Task — Phoenix Agentic Engine
+
+- **Issue:** #N — Short description
+- **PR:** #N (if open)
+- **Branch:** `feature/branch-name`
+- **Board status:** In Progress
+- **Phase:** Phase N
+- **Depends on:** (cross-repo dependencies, if any)
+- **Key files:**
+  - `path/to/file1`
+  - `path/to/file2`
+- **Last checkpoint:** What was completed last session
+- **Next step:** The immediate next action to take
+- **Blocked by:** (anything blocking progress, or "nothing")
+
+### Acceptance criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+```
+
+## Privacy note
+
+This repo is **public**. Do NOT include:
+- API keys, secrets, or credentials
+- Private strategy details
+- Internal business logic descriptions
+- References to private repo internals beyond repo names

--- a/.github/docs/PROJECT_WORKFLOW.md
+++ b/.github/docs/PROJECT_WORKFLOW.md
@@ -1,0 +1,229 @@
+# Phoenix Project Workflow
+
+This document describes the task management system used across all Phoenix repos.
+
+## Overview
+
+All Phoenix repos share a unified project board and task lifecycle called the **Ralph Loop** — a conditional iteration loop where each cycle picks a task, works it, completes it, and selects the next one. The loop includes a branch point for **local (IDE) vs. cloud agent** execution.
+
+
+
+**Repos in this system:**
+| Repo | Visibility | Description |
+|------|-----------|-------------|
+| `Phoenix-Agentic-Engine` | Public | Godot fork — the game engine |
+| `Phoenix-Agentic-Engine-Backend` | Private | .NET Gateway + Python worker runtime |
+| `Phoenix-Agentic-Engine-Interface` | Public | TypeScript SDK — contracts between Engine and Backend |
+| `Phoenix-Agentic-Website-Frontend` | Public | Next.js public website |
+| `Phoenix-Agentic-Website-Backend` | Private | .NET API for website services |
+
+---
+
+## The Ralph Loop
+
+The Ralph Loop is the core task lifecycle. It is a **conditional iteration loop** — not a simple cycle, but a loop with a decision point that determines *how* each task is executed.
+
+```
+┌──────────────────────────────────────────────────────┐
+│                   RALPH LOOP                         │
+│                                                      │
+│  ┌─────────────┐                                     │
+│  │  PICK TASK   │ ◄──────────────────────────────┐   │
+│  │  from board  │                                │   │
+│  └──────┬───────┘                                │   │
+│         │                                        │   │
+│         ▼                                        │   │
+│  ┌─────────────────┐                             │   │
+│  │  DECISION POINT  │                            │   │
+│  │  Local or Cloud? │                            │   │
+│  └───┬─────────┬────┘                            │   │
+│      │         │                                 │   │
+│  Local IDE  Cloud Agent                          │   │
+│      │         │                                 │   │
+│      ▼         ▼                                 │   │
+│  ┌────────┐ ┌──────────────┐                     │   │
+│  │  WORK  │ │ Copilot CCA  │                     │   │
+│  │  in VS │ │ works async  │                     │   │
+│  │  Code  │ │ opens PR     │                     │   │
+│  └───┬────┘ └──────┬───────┘                     │   │
+│      │             │                             │   │
+│      ▼             ▼                             │   │
+│  ┌─────────────────────┐                         │   │
+│  │   REVIEW + MERGE    │                         │   │
+│  │   (In Review → Done)│                         │   │
+│  └──────────┬──────────┘                         │   │
+│             │                                    │   │
+│             ▼                                    │   │
+│  ┌─────────────────────┐                         │   │
+│  │  RESET CURRENT_TASK │                         │   │
+│  │  pick next task ────┼─────────────────────────┘   │
+│  └─────────────────────┘                             │
+│                                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+### Loop Phases
+
+#### 1. PICK — Select the next task
+- Read `.github/context/CURRENT_TASK.md` to confirm no active task
+- Check the project board for items in **Ready** column
+- If nothing in Ready, check **Backlog** and promote the highest-priority item
+- Use the `focus` skill: say "pick next task" or "what should I work on?"
+- The agent reads the roadmap, checks the board, and recommends the next task
+- Create/assign a GitHub issue if one doesn't exist
+
+#### 2. DECIDE — Local IDE or Cloud Agent?
+- **Local IDE**: Complex work requiring human judgment, multi-file refactors, architecture decisions, debugging
+- **Cloud Agent**: Well-scoped, self-contained tasks with clear acceptance criteria — bug fixes, test additions, doc updates, simple features
+- On the project board, set the **Work mode** field to "Local (IDE)" or "Cloud Agent"
+- If Cloud Agent: add the `cloud-agent` label to the issue → automation assigns Copilot
+
+#### 3. WORK — Execute the task
+- **Local path**: Agent fills in `CURRENT_TASK.md`, you work in VS Code, agent helps via chat, checkpoints are saved periodically
+- **Cloud path**: Copilot coding agent works autonomously, opens a PR, you review when done
+- **Tangent handling**: If a bug or side task comes up during Local work, the tangent chat reads `CURRENT_TASK.md` and knows it's a tangent — the main task context is preserved
+
+#### 4. REVIEW — Validate and merge
+- PR is opened → board item moves to **In Review**
+- Code review (human or Copilot review)
+- Merge when approved
+
+#### 5. RESET — Complete and loop
+- Board item moves to **Done**
+- `CURRENT_TASK.md` is reset to "no active task"
+- The `focus` skill offers to pick the next task
+- Loop restarts
+
+---
+
+## Issue Hierarchy — Epics, Features, Tasks
+
+Use GitHub's **sub-issues** feature to structure work in a hierarchy. This creates traceability from high-level goals down to individual PRs.
+
+### Three-Level Hierarchy
+
+```
+Epic (high-level goal, spans multiple repos)
+├── Feature (deliverable, usually one repo)
+│   ├── Task (implementable unit → becomes a PR)
+│   ├── Task
+│   └── Task
+├── Feature (another repo)
+│   ├── Task
+│   └── Task
+└── Feature
+    └── Task
+```
+
+### Level Definitions
+
+| Level | Scope | Lifetime | Label | Example |
+|-------|-------|----------|-------|---------|
+| **Epic** | Multi-repo milestone | Weeks–months | `epic` | "Phase 3: .NET Gateway + Service Bus wiring" |
+| **Feature** | Single repo deliverable | Days–weeks | `feature` | "Implement JWT auth middleware in Gateway" |
+| **Task** | Single PR unit of work | Hours–days | `task` | "Add token validation to auth pipeline" |
+
+### How to Create the Hierarchy
+
+1. **Create the Epic issue** in the primary repo (usually where most work happens)
+   - Title: `[Epic] Phase 3: .NET Gateway + Service Bus wiring`
+   - Label: `epic`
+   - Add to project board
+
+2. **Create Feature issues** as sub-issues of the Epic
+   - In the Epic issue, click **"Add sub-issue"**
+   - Sub-issues can be in **different repos** — an Engine Epic can have Backend sub-issues
+   - Label: `feature`
+
+3. **Create Task issues** as sub-issues of Features
+   - In the Feature issue, click **"Add sub-issue"**
+   - Label: `task`
+   - These map 1:1 to PRs
+
+### Cross-Repo Sub-Issues
+
+Sub-issues work across repos. Example structure:
+
+```
+Epic #10 in Phoenix-Agentic-Engine-Backend:
+  "[Epic] Phase 3: Gateway + Service Bus"
+  ├── Feature #11 (Backend): "JWT auth middleware"
+  │   ├── Task #12 (Backend): "Add token validation"
+  │   └── Task #13 (Backend): "Add role-based access"
+  ├── Feature #5 (Interface): "Auth contract types"
+  │   └── Task #6 (Interface): "Add AuthToken schema"
+  └── Feature #20 (Engine): "Update adapter for auth"
+      └── Task #21 (Engine): "Wire new auth headers"
+```
+
+The project board shows all of these regardless of which repo they live in.
+
+### Labels to Use
+
+Create these labels in each repo:
+- `epic` — Multi-repo milestone
+- `feature` — Repo-level deliverable
+- `task` — PR-level unit of work
+- `cloud-agent` — Assign to Copilot coding agent
+- `blocked` — Cannot proceed (note reason in issue)
+
+---
+
+## Cloud Agent Auto-Assignment
+
+When you decide a task should be handled by Copilot coding agent instead of locally in your IDE:
+
+### How It Works
+
+1. Create the issue in the appropriate repo
+2. Add the `cloud-agent` label to the issue
+3. The `cloud-agent-assign.yml` workflow fires automatically
+4. The workflow assigns Copilot to the issue
+5. Copilot coding agent picks up the issue, works on it, and opens a PR
+6. The `project-board-sync.yml` workflow auto-adds the PR to the project board
+7. You review the PR in the "In Review" column
+
+### When to Use Cloud Agent
+
+**Good candidates:**
+- Bug fixes with clear reproduction steps
+- Adding or updating tests
+- Documentation updates
+- Simple, well-scoped features with clear acceptance criteria
+- Code formatting, linting, or hygiene tasks
+
+**Keep local:**
+- Multi-repo coordinated changes
+- Architecture decisions
+- Debugging complex issues requiring IDE context
+- Performance optimization requiring profiling
+- Anything requiring access to running services or local state
+
+### From the Project Board
+
+1. Move the issue to **Ready**
+2. Set the **Work mode** field to "Cloud Agent"
+3. Go to the issue and add the `cloud-agent` label
+4. Copilot picks it up automatically
+
+---
+
+## Automations in This Repo
+
+| Workflow | Trigger | Action |
+|----------|---------|--------|
+| `project-board-sync.yml` | Issue opened/reopened, PR opened/reopened | Adds item to Phoenix Project Board |
+| `cloud-agent-assign.yml` | Issue labeled `cloud-agent` | Assigns Copilot coding agent to the issue |
+
+---
+
+## Files in This System
+
+| File | Purpose |
+|------|---------|
+| `.github/context/CURRENT_TASK.md` | Active task pointer — read by agents at session start |
+| `.github/instructions/*-current-task.instructions.md` | Instruction telling agents to read CURRENT_TASK.md |
+| `.github/skills/focus/SKILL.md` | Skill for resume/pick/checkpoint/complete workflows |
+| `.github/workflows/project-board-sync.yml` | Auto-add issues/PRs to project board |
+| `.github/workflows/cloud-agent-assign.yml` | Auto-assign Copilot when `cloud-agent` label is added |
+| `.github/docs/PROJECT_WORKFLOW.md` | This document |

--- a/.github/docs/PROJECT_WORKFLOW.md
+++ b/.github/docs/PROJECT_WORKFLOW.md
@@ -100,28 +100,34 @@ The Ralph Loop is the core task lifecycle. It is a **conditional iteration loop*
 
 Use GitHub's **sub-issues** feature to structure work in a hierarchy. This creates traceability from high-level goals down to individual PRs.
 
-### Three-Level Hierarchy
+### Three-Level Hierarchy with Branch Mapping
 
 ```
 Epic (high-level goal, spans multiple repos)
+│   Branch: feature/<topic>  →  PR targets main
 ├── Feature (deliverable, usually one repo)
-│   ├── Task (implementable unit → becomes a PR)
-│   ├── Task
-│   └── Task
+│   ├── Task  →  subfeature/task/<desc>      →  PR targets feature/<topic>
+│   ├── Bug   →  subfeature/bugfix/<desc>     →  PR targets feature/<topic>
+│   └── Chore →  subfeature/chore/<desc>      →  PR targets feature/<topic>
 ├── Feature (another repo)
-│   ├── Task
-│   └── Task
+│   ├── Task  →  subfeature/task/<desc>       →  PR targets feature/<topic>
+│   └── Test  →  subfeature/test/<desc>       →  PR targets feature/<topic>
 └── Feature
-    └── Task
+    └── Docs  →  subfeature/docs/<desc>       →  PR targets feature/<topic>
 ```
 
 ### Level Definitions
 
-| Level | Scope | Lifetime | Label | Example |
-|-------|-------|----------|-------|---------|
-| **Epic** | Multi-repo milestone | Weeks–months | `epic` | "Phase 3: .NET Gateway + Service Bus wiring" |
-| **Feature** | Single repo deliverable | Days–weeks | `feature` | "Implement JWT auth middleware in Gateway" |
-| **Task** | Single PR unit of work | Hours–days | `task` | "Add token validation to auth pipeline" |
+| Level | Scope | Lifetime | Label | Branch pattern | Example |
+|-------|-------|----------|-------|----------------|---------|
+| **Epic** | Multi-repo milestone | Weeks–months | `epic` | `feature/<topic>` → PR to `main` | "Phase 3: .NET Gateway + Service Bus wiring" |
+| **Feature** | Single repo deliverable | Days–weeks | `feature` | (same as parent epic branch) | "Implement JWT auth middleware in Gateway" |
+| **Task** | Single PR unit of work | Hours–days | `task` | `subfeature/task/<desc>` → PR to `feature/*` | "Add token validation to auth pipeline" |
+| **Bug** | Bug fix within a feature | Hours–days | `bug` | `subfeature/bugfix/<desc>` → PR to `feature/*` | "Fix token expiry edge case" |
+| **Refactor** | Code restructuring | Hours–days | `refactor` | `subfeature/refactor/<desc>` → PR to `feature/*` | "Extract validation into middleware" |
+| **Test** | Test additions/fixes | Hours–days | `test` | `subfeature/test/<desc>` → PR to `feature/*` | "Add auth integration tests" |
+| **Docs** | Documentation | Hours–days | `docs` | `subfeature/docs/<desc>` → PR to `feature/*` | "Document auth flow" |
+| **Chore** | Maintenance/tooling | Hours–days | `chore` | `subfeature/chore/<desc>` → PR to `feature/*` | "Update CI pipeline" |
 
 ### How to Create the Hierarchy
 
@@ -161,9 +167,14 @@ The project board shows all of these regardless of which repo they live in.
 ### Labels to Use
 
 Create these labels in each repo:
-- `epic` — Multi-repo milestone
-- `feature` — Repo-level deliverable
-- `task` — PR-level unit of work
+- `epic` — Multi-repo milestone → maps to `feature/<topic>` branch
+- `feature` — Repo-level deliverable (sub-issue of epic)
+- `task` — PR-level unit of work → maps to `subfeature/task/<desc>` branch
+- `bug` — Bug fix → maps to `subfeature/bugfix/<desc>` branch
+- `refactor` — Code restructuring → maps to `subfeature/refactor/<desc>` branch
+- `test` — Test additions/fixes → maps to `subfeature/test/<desc>` branch
+- `docs` — Documentation → maps to `subfeature/docs/<desc>` branch
+- `chore` — Maintenance/tooling → maps to `subfeature/chore/<desc>` branch
 - `cloud-agent` — Assign to Copilot coding agent
 - `blocked` — Cannot proceed (note reason in issue)
 

--- a/.github/instructions/engine-build-and-test.instructions.md
+++ b/.github/instructions/engine-build-and-test.instructions.md
@@ -31,6 +31,16 @@ C:\Python313\python.exe -m pre_commit install
 C:\Python313\python.exe -m pre_commit run --all-files
 ```
 
+## Git hygiene before commit/push
+
+- Use terminal Git commands from the Engine repo (`git add`, `git commit`, `git push`) so local hooks run consistently.
+- Do not bypass hooks with `--no-verify` in normal development.
+- If `git commit` auto-runs pre-commit hooks and they modify files, re-stage those files and re-run `git commit`.
+- Before pushing, run either:
+	- full checks: `C:\Python313\python.exe -m pre_commit run --all-files`
+	- targeted checks for touched files: `C:\Python313\python.exe -m pre_commit run --files <file1> <file2>`
+- Treat any pre-commit failure as a block for push until fixed.
+
 ## Phoenix addon packaging expectations
 
 Editor artifact validation should include these staged paths when relevant:

--- a/.github/instructions/engine-build-and-test.instructions.md
+++ b/.github/instructions/engine-build-and-test.instructions.md
@@ -41,6 +41,19 @@ C:\Python313\python.exe -m pre_commit run --all-files
 	- targeted checks for touched files: `C:\Python313\python.exe -m pre_commit run --files <file1> <file2>`
 - Treat any pre-commit failure as a block for push until fixed.
 
+## VS Code validation tasks (separate from pre-commit)
+
+Run these tasks as an additional gate before commit/push:
+
+- `dev: verify: check` — runs `dev: build editor` then headless version/startup smoke checks.
+- `dev: verify: check (full)` — same as above plus headless doctool check to a temp output directory.
+
+Available focused tasks:
+
+- `dev: verify: headless:version`
+- `dev: verify: headless:startup`
+- `dev: verify: headless:doctool-temp`
+
 ## Phoenix addon packaging expectations
 
 Editor artifact validation should include these staged paths when relevant:
@@ -57,3 +70,4 @@ Editor artifact validation should include these staged paths when relevant:
 - Include build/test commands and platform in PR notes.
 - Keep tests deterministic and local-only.
 - Verify changed addon integrations still stage and bootstrap in editor builds.
+- Run `dev: verify: check` (or `dev: verify: check (full)` when touching doc-exposed/editor-surface code) before commit/push.

--- a/.github/instructions/engine-code-review.instructions.md
+++ b/.github/instructions/engine-code-review.instructions.md
@@ -36,6 +36,8 @@ Priorities: minimal diffs, low upstream-merge risk, deterministic build/package 
 
 - Prefer MCP GitHub tools for PR operations when acting as assistant (list/create/update/request review).
 - Treat Copilot review comments as actionable items: fix or respond with rationale.
+- Copilot review requests are automatic but budgeted: check whether a Copilot review is already requested/completed on the PR before requesting.
+- Do not request duplicate Copilot reviews by default; request at most one per PR unless user explicitly asks for another round after substantial new changes.
 - Require re-validation (pre-commit + relevant tests/build checks) before marking review feedback as addressed.
 - Check PR status checks and GitHub Actions workflow runs; if failures exist, debug and fix before approval/merge.
 - Verify branch/base targets are correct before merge (typically into `feature/agent-backend-integration` unless explicitly overridden).

--- a/.github/instructions/engine-code-review.instructions.md
+++ b/.github/instructions/engine-code-review.instructions.md
@@ -32,12 +32,32 @@ Priorities: minimal diffs, low upstream-merge risk, deterministic build/package 
 - Avoid direct edits inside vendored third-party trees under `modules/ultimate_ai/external/*` unless intentionally updating submodule pointers.
 - Reject prompt templates, secrets, credentials, or backend-only proprietary logic in public client code.
 
+## CLI tool policy (mandatory)
+
+- **NEVER use `gh` CLI** — it is not installed and must not be used.
+- **Always prefer GitHub MCP tools** (`mcp_github_*`) for all GitHub operations (PRs, issues, reviews, actions, branches, searches).
+- Fall back to terminal `git` commands only for local worktree operations or when MCP tools fail.
+- Do NOT suggest or attempt any `gh` subcommand.
+
 ## PR workflow hygiene
 
-- Prefer MCP GitHub tools for PR operations when acting as assistant (list/create/update/request review).
+- **Always use GitHub MCP tools** for PR operations — never `gh` CLI.
 - Treat Copilot review comments as actionable items: fix or respond with rationale.
 - Copilot review requests are automatic but budgeted: check whether a Copilot review is already requested/completed on the PR before requesting.
 - Do not request duplicate Copilot reviews by default; request at most one per PR unless user explicitly asks for another round after substantial new changes.
 - Require re-validation (pre-commit + relevant tests/build checks) before marking review feedback as addressed.
 - Check PR status checks and GitHub Actions workflow runs; if failures exist, debug and fix before approval/merge.
 - Verify branch/base targets are correct before merge (typically into `feature/agent-backend-integration` unless explicitly overridden).
+
+## PR size discipline
+
+- Keep PRs small and focused — one logical change per PR.
+- If a feature branch grows large, break it into sub-branches targeting the feature branch, then merge the feature branch into `main`.
+- Target: PRs should ideally be under ~400 lines of meaningful change.
+- Flag oversized PRs and request splitting.
+
+## Issue creation (public repo)
+
+- Create issues for trackable work using GitHub MCP tools — never `gh issue create`.
+- For non-sensitive, public-facing work: assign to Copilot (cloud agent) using `mcp_github_github_assign_copilot_to_issue`.
+- Do NOT create public issues for private/sensitive matters (secrets, auth, proprietary logic, security vulnerabilities).

--- a/.github/instructions/engine-code-review.instructions.md
+++ b/.github/instructions/engine-code-review.instructions.md
@@ -31,3 +31,11 @@ Priorities: minimal diffs, low upstream-merge risk, deterministic build/package 
 - Keep PRs narrow; split unrelated refactors.
 - Avoid direct edits inside vendored third-party trees under `modules/ultimate_ai/external/*` unless intentionally updating submodule pointers.
 - Reject prompt templates, secrets, credentials, or backend-only proprietary logic in public client code.
+
+## PR workflow hygiene
+
+- Prefer MCP GitHub tools for PR operations when acting as assistant (list/create/update/request review).
+- Treat Copilot review comments as actionable items: fix or respond with rationale.
+- Require re-validation (pre-commit + relevant tests/build checks) before marking review feedback as addressed.
+- Check PR status checks and GitHub Actions workflow runs; if failures exist, debug and fix before approval/merge.
+- Verify branch/base targets are correct before merge (typically into `feature/agent-backend-integration` unless explicitly overridden).

--- a/.github/instructions/engine-coding-conventions.instructions.md
+++ b/.github/instructions/engine-coding-conventions.instructions.md
@@ -30,3 +30,11 @@ Match the style of the file you are editing (indentation, naming, include order,
 - New global state/singletons without strong justification.
 - Per-frame avoidable allocations/string churn in hot paths.
 - Cross-cutting refactors unrelated to the requested change.
+
+## Git hygiene conventions
+
+- Keep commits focused and minimal; do not mix unrelated changes in one commit.
+- Stage intentionally (avoid broad `git add .` when narrowing scope matters).
+- Run pre-commit checks before push (or let `git commit` hooks run and resolve all hook failures).
+- If hooks rewrite files, re-stage and commit again so committed content matches hook output.
+- Avoid force-pushing shared branches unless explicitly coordinated.

--- a/.github/instructions/engine-current-task.instructions.md
+++ b/.github/instructions/engine-current-task.instructions.md
@@ -14,12 +14,23 @@ All tasks are tracked on the **Phoenix Project Board**: https://github.com/users
 
 Board columns: Backlog → Ready → In Progress → In Review → Done
 
-## Task lifecycle
+## Task lifecycle (Ralph Loop)
+
+The task lifecycle follows the **Ralph Loop** — a conditional iteration loop. See `.github/docs/PROJECT_WORKFLOW.md` for the full diagram and documentation.
 
 1. **Pick**: Read roadmap → select next task → create/assign issue → fill CURRENT_TASK.md → move to "In Progress"
-2. **Work**: Implement the task, updating checkpoint in CURRENT_TASK.md periodically
-3. **Complete**: Verify acceptance criteria → move to "In Review"/"Done" → reset CURRENT_TASK.md
-4. **Next**: Repeat from step 1
+2. **Decide**: Local IDE or Cloud Agent? If cloud, add `cloud-agent` label to auto-assign Copilot
+3. **Work**: Implement the task, updating checkpoint in CURRENT_TASK.md periodically
+4. **Complete**: Verify acceptance criteria → move to "In Review"/"Done" → reset CURRENT_TASK.md
+5. **Next**: Repeat from step 1
+
+## Issue hierarchy
+
+Use GitHub sub-issues for structured work: **Epic** → **Feature** → **Task**. Sub-issues can cross repos.
+
+## Cloud agent assignment
+
+When an issue is labeled `cloud-agent`, the `cloud-agent-assign.yml` workflow auto-assigns Copilot coding agent. Use this for well-scoped tasks with clear acceptance criteria.
 
 ## Cross-repo coordination
 

--- a/.github/instructions/engine-current-task.instructions.md
+++ b/.github/instructions/engine-current-task.instructions.md
@@ -1,0 +1,33 @@
+# PRIORITY — Current Task Context
+
+## Active task pointer
+
+**Read `.github/context/CURRENT_TASK.md` at the start of every session.** This file is the single source of truth for what is actively being worked on in this repo.
+
+- If the file contains an active task: that is your primary context. All work should relate to or acknowledge this task.
+- If the file says "No active task": use the `focus` skill to pick the next task from the roadmap.
+- If you are spawned for a side task (bug fix, tangent): still read CURRENT_TASK.md to understand the main thread. Note in your response that the main task is X and this is a tangent.
+
+## Project board
+
+All tasks are tracked on the **Phoenix Project Board**: https://github.com/users/rivie13/projects/3
+
+Board columns: Backlog → Ready → In Progress → In Review → Done
+
+## Task lifecycle
+
+1. **Pick**: Read roadmap → select next task → create/assign issue → fill CURRENT_TASK.md → move to "In Progress"
+2. **Work**: Implement the task, updating checkpoint in CURRENT_TASK.md periodically
+3. **Complete**: Verify acceptance criteria → move to "In Review"/"Done" → reset CURRENT_TASK.md
+4. **Next**: Repeat from step 1
+
+## Cross-repo coordination
+
+When a task in this repo depends on or affects another repo:
+- Note the dependency in CURRENT_TASK.md "Depends on" field
+- Check the other repo's CURRENT_TASK.md to avoid conflicts
+- Related repos: Backend (`rivie13/Phoenix-Agentic-Engine-Backend`), Interface (`rivie13/Phoenix-Agentic-Engine-Interface`)
+
+## Privacy
+
+This repo is **public**. CURRENT_TASK.md must not contain secrets, private strategy, or internal business details.

--- a/.github/instructions/engine-git-hygiene.instructions.md
+++ b/.github/instructions/engine-git-hygiene.instructions.md
@@ -14,15 +14,66 @@ Use it whenever making code changes, preparing pull requests, or handling review
 
 ## Branch hygiene
 
-- Always branch from the target base (usually `feature/agent-backend-integration` or `main`).
-- Keep one focused concern per branch/PR.
-- Branch naming:
-  - `feature/<short-topic>`
-  - `fix/<short-topic>`
-  - `mcp-docs/<short-topic>`
-  - `chore/<short-topic>` for non-functional maintenance
-- Avoid direct commits to shared integration branches.
-- Rebase/sync regularly with the base branch to reduce merge drift.
+### Hierarchy
+
+There are **three branch tiers**:
+
+| Tier | Pattern | Branches from | Merges into | Purpose |
+|------|---------|---------------|-------------|---------|
+| **main** | `main` | — | — | Stable release line |
+| **feature** | `feature/<topic>` | `main` | `main` | Large, multi-PR deliverable |
+| **subfeature** | `subfeature/<type>/<description>` | parent `feature/*` | parent `feature/*` | Focused piece of work within a feature |
+
+### Feature branches (`feature/*`)
+
+- Branch from `main` for new top-level work.
+- Merged into `main` **only when the entire feature is complete and validated**.
+- The final `feature → main` PR will be large — that is expected and acceptable.
+- Keep one focused feature per branch.
+
+### Subfeature branches (`subfeature/*`)
+
+Subfeature branches are the primary unit of daily work. They branch off a parent `feature/*` branch and merge back into it via small, focused PRs.
+
+**Naming convention** — always three segments:
+
+```
+subfeature/<type>/<short-description>
+```
+
+Where `<type>` is one of:
+
+| Type | Use for |
+|------|---------|
+| `task` | Planned implementation work |
+| `bugfix` | Bug discovered during feature development |
+| `refactor` | Structural improvement within the feature |
+| `test` | Adding/improving tests for the feature |
+| `docs` | Documentation specific to the feature |
+| `chore` | Non-functional maintenance (deps, config, formatting) |
+
+**Examples:**
+- `subfeature/task/wire-up-assistant-panel`
+- `subfeature/bugfix/fix-panel-null-crash`
+- `subfeature/refactor/extract-message-renderer`
+- `subfeature/test/add-panel-unit-tests`
+- `subfeature/docs/update-architecture-after-panel`
+
+### Top-level branches (non-feature work)
+
+For small, standalone changes that do not belong to a larger feature:
+- `fix/<short-topic>` — standalone bug fixes (branches from and merges to `main`)
+Examples:
+- `chore/<short-topic>` — non-functional maintenance
+- `mcp-docs/<short-topic>` — mcp docs server work
+- `docs/<short-topic>` — documentation work
+
+### Rules
+
+- Avoid direct commits to `main` or shared `feature/*` branches.
+- Rebase/sync regularly with the parent branch to reduce merge drift.
+- **Subfeature branches MUST target their parent `feature/*` branch** — never `main` directly.
+- Delete subfeature branches after merge into the feature branch.
 
 ## Commit hygiene
 
@@ -41,12 +92,14 @@ Use it whenever making code changes, preparing pull requests, or handling review
 ## PR size discipline (mandatory)
 
 - Keep PRs small and focused — one logical change per PR.
-- If a feature branch grows large, break it into sub-branches:
-  1. Create sub-branches off the feature branch for discrete pieces of work.
-  2. Open PRs from each sub-branch into the feature branch.
-  3. Once sub-branch PRs are merged into the feature branch, open a single PR from the feature branch into `main`.
-- Target: PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
-- If a PR exceeds this, strongly consider splitting before requesting review.
+- **Subfeature → feature PRs** should be the normal unit of review. Each should cover one discrete piece of work.
+- **Feature → main PRs** will be large (accumulating all merged subfeature work). This is expected. The feature-level PR serves as the final integration gate and should summarize all subfeature PRs that were merged.
+- Break work into subfeature branches early. Do not wait until a feature branch is bloated to split.
+  1. Create `subfeature/<type>/<description>` branches off the parent `feature/*` branch.
+  2. Open PRs from each subfeature branch into the `feature/*` branch.
+  3. Once all subfeature PRs are merged and the feature is complete, open a single PR from `feature/*` into `main`.
+- Target: subfeature PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
+- If a subfeature PR exceeds this, strongly consider splitting into further subfeature branches.
 - Never let PRs accumulate dozens of unrelated changes — this makes review impossible and increases merge risk.
 
 ## Pull request hygiene
@@ -102,6 +155,26 @@ Terminal git is still appropriate for local worktree tasks (status, branch, add/
 - For public-facing, non-sensitive issues: assign to Copilot (cloud agent) when appropriate using `mcp_github_github_assign_copilot_to_issue`.
 - Do NOT create public issues or assign to Copilot for work involving private/sensitive matters (secrets, auth internals, proprietary logic, infrastructure details, security vulnerabilities).
 - Search for existing issues before creating duplicates using `mcp_github_github_search_issues`.
+
+### Issue–branch alignment (mandatory)
+
+Issues must mirror the branch hierarchy so that work is traceable:
+
+| Issue type | Label | Maps to branch | Description |
+|------------|-------|----------------|-------------|
+| **Epic** | `epic` | `feature/<topic>` | Multi-PR deliverable; the parent issue for all subfeature work |
+| **Task** | `task` | `subfeature/task/<desc>` | Planned implementation work within the feature |
+| **Bug** | `bug` | `subfeature/bugfix/<desc>` | Bug found during feature development |
+| **Refactor** | `refactor` | `subfeature/refactor/<desc>` | Structural cleanup within the feature |
+| **Test** | `test` | `subfeature/test/<desc>` | Test coverage for the feature |
+| **Docs** | `docs` | `subfeature/docs/<desc>` | Documentation for the feature |
+| **Chore** | `chore` | `subfeature/chore/<desc>` | Non-functional maintenance |
+
+- **Epic issues** should be created for each `feature/*` branch. They act as the parent tracker.
+- **Sub-issues** should be created for each `subfeature/*` branch using `mcp_github_github_sub_issue_write`. Each sub-issue links to its parent epic.
+- When creating a subfeature PR, reference its sub-issue with `Closes #N`.
+- When merging the final `feature → main` PR, reference the parent epic with `Closes #N`.
+- This creates a clear audit trail: epic → sub-issues → subfeature PRs → feature PR → main.
 
 ## Engine quality gate (required before PR readiness)
 

--- a/.github/instructions/engine-git-hygiene.instructions.md
+++ b/.github/instructions/engine-git-hygiene.instructions.md
@@ -1,0 +1,112 @@
+# Git hygiene and GitHub MCP workflow — Phoenix Agentic Engine
+
+## Scope
+
+This file defines branch, commit, validation, and pull request hygiene for the Engine repo (Godot fork).
+Use it whenever making code changes, preparing pull requests, or handling review feedback.
+
+## CLI tool policy (mandatory)
+
+- **NEVER use `gh` CLI** — it is not installed in this environment and must not be used.
+- **Always prefer GitHub MCP tools** (`mcp_github_*`) for all GitHub operations (PRs, issues, reviews, actions, branches, searches, etc.).
+- Fall back to terminal `git` commands only for local worktree operations (status, add, commit, branch, checkout, rebase, push, pull, diff, log) or when MCP tools fail/are unavailable.
+- Do NOT suggest or attempt `gh pr create`, `gh issue create`, `gh run list`, or any other `gh` subcommand.
+
+## Branch hygiene
+
+- Always branch from the target base (usually `feature/agent-backend-integration` or `main`).
+- Keep one focused concern per branch/PR.
+- Branch naming:
+  - `feature/<short-topic>`
+  - `fix/<short-topic>`
+  - `mcp-docs/<short-topic>`
+  - `chore/<short-topic>` for non-functional maintenance
+- Avoid direct commits to shared integration branches.
+- Rebase/sync regularly with the base branch to reduce merge drift.
+
+## Commit hygiene
+
+- Run validations before commit:
+  - `C:\Python313\python.exe -m pre_commit run --all-files`
+  - Build: `C:\Python313\python.exe -m SCons platform=windows target=editor d3d12=no`
+- Keep commits atomic and reviewable.
+- Commit message style (recommended):
+  - `feat: ...`
+  - `fix: ...`
+  - `chore: ...`
+  - `test: ...`
+  - `docs: ...`
+- Do not include unrelated file changes in the same commit.
+
+## PR size discipline (mandatory)
+
+- Keep PRs small and focused — one logical change per PR.
+- If a feature branch grows large, break it into sub-branches:
+  1. Create sub-branches off the feature branch for discrete pieces of work.
+  2. Open PRs from each sub-branch into the feature branch.
+  3. Once sub-branch PRs are merged into the feature branch, open a single PR from the feature branch into `main`.
+- Target: PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
+- If a PR exceeds this, strongly consider splitting before requesting review.
+- Never let PRs accumulate dozens of unrelated changes — this makes review impossible and increases merge risk.
+
+## Pull request hygiene
+
+- **Always use GitHub MCP tools** for PR operations — never `gh` CLI.
+- Before creating PR:
+  - Ensure branch is up to date with base
+  - Ensure pre-commit and build pass
+  - Confirm scope is limited to one logical change
+- After creating/updating PR:
+  - Check GitHub Actions/workflow run status for the PR
+  - If any workflow/job fails, fetch logs and fix the root cause
+  - Re-run validations locally and re-check workflow runs
+  - Do not mark PR ready while required checks are failing
+- PR description MUST include (use MCP tools to set):
+  - **Summary**: What changed and why
+  - **Changes**: Bullet list of key changes
+  - **Testing**: What was tested and how, with pass/fail results
+  - **Breaking changes**: Any upstream-merge or compatibility concerns
+  - **Related issues**: Link related issues with `Closes #N` or `Relates to #N`
+  - If core files changed: justification and `CORE_MODIFICATIONS.md` entry
+- Treat Copilot review as auto-requested by default when available.
+- Only request Copilot review manually when no Copilot review exists for the latest commit set on the PR.
+
+## Review hygiene (Copilot + humans)
+
+- Fetch and address unresolved review comments.
+- For each comment:
+  1. Reproduce/understand issue
+  2. Apply focused fix
+  3. Re-run relevant validations
+  4. Respond with what changed and why
+- Re-request review when follow-up changes are done.
+
+## GitHub MCP tool preference
+
+Prefer MCP tools over raw terminal git/GitHub commands for:
+- Creating and updating PRs
+- Listing PRs/reviews/comments
+- Checking whether Copilot review already exists
+- Requesting Copilot review only when missing for latest commits
+- Reading and responding to review feedback
+- Listing workflow runs/jobs and reviewing failed logs
+- Creating and managing issues
+- Searching for existing issues
+
+Terminal git is still appropriate for local worktree tasks (status, branch, add/commit, rebase, push, tests).
+
+## Issue creation and Copilot assignment (public repo)
+
+- Create GitHub issues for trackable work items using `mcp_github_github_issue_write`.
+- Use issues to break large features into smaller, trackable units of work.
+- For public-facing, non-sensitive issues: assign to Copilot (cloud agent) when appropriate using `mcp_github_github_assign_copilot_to_issue`.
+- Do NOT create public issues or assign to Copilot for work involving private/sensitive matters (secrets, auth internals, proprietary logic, infrastructure details, security vulnerabilities).
+- Search for existing issues before creating duplicates using `mcp_github_github_search_issues`.
+
+## Engine quality gate (required before PR readiness)
+
+- `pre_commit run --all-files` passes
+- SCons build succeeds
+- PR GitHub Actions checks are green (or explicitly understood/waived)
+- Changes in `modules/ultimate_ai/` are expected; changes outside require `CORE_MODIFICATIONS.md` entry
+- No secrets, credentials, or prompt content committed

--- a/.github/skills/build-and-test/SKILL.md
+++ b/.github/skills/build-and-test/SKILL.md
@@ -31,7 +31,7 @@ Always invoke SCons with the full Python path to avoid PATH mismatches.
 C:\Python313\python.exe -m SCons platform=windows target=editor d3d12=no
 
 # Compiled binary
-bin\godot.windows.editor.x86_64.exe
+bin\phoenix_agentic.windows.editor.x86_64.exe
 ```
 
 ### Other Platforms
@@ -80,14 +80,27 @@ C:\Python313\python.exe -m pre_commit run --files <changed-file-1> <changed-file
 C:\Python313\python.exe -m pre_commit run --all-files
 ```
 
+## Extra VS Code validation tasks (separate from pre-commit)
+
+Run these before commit/push as additional safety checks:
+
+| Task label | What it does |
+|------------|---------------|
+| `dev: verify: check` | Runs `dev: build editor` + headless version/startup smoke checks |
+| `dev: verify: check (full)` | Runs `dev: verify: check` plus headless doctool check to temp dir |
+| `dev: verify: headless:version` | Runs editor with `--headless --version` |
+| `dev: verify: headless:startup` | Runs editor with `--headless --quit` |
+| `dev: verify: headless:doctool-temp` | Runs `--doctool <temp-dir> --headless` and cleans temp output |
+
 ## Validation checklist
 
 When the user asks to validate or check their work:
 
 1. **Pre-commit passes** — run `pre_commit run --all-files`
 2. **Build succeeds** — run the SCons build command above
-3. **Binary launches** — confirm `bin\godot.windows.editor.x86_64.exe` starts without crash
-4. **No regressions** — if editing core files, check that existing functionality still works
+3. **Headless checks pass** — run `dev: verify: check` (or `dev: verify: check (full)`)
+4. **Binary launches (interactive smoke)** — confirm `bin\phoenix_agentic.windows.editor.x86_64.exe` starts without crash when needed
+5. **No regressions** — if editing core files, check that existing functionality still works
 
 ## Common build errors and fixes
 
@@ -104,5 +117,6 @@ When the user asks to validate or check their work:
 1. Make code changes
 2. Run pre-commit on changed files
 3. Build with SCons
-4. Launch editor binary to smoke-test
-5. Report: what was built, what was tested, platform used
+4. Run `dev: verify: check` (or `dev: verify: check (full)`)
+5. Launch editor binary to smoke-test when relevant
+6. Report: what was built, what was tested, platform used

--- a/.github/skills/build-and-test/SKILL.md
+++ b/.github/skills/build-and-test/SKILL.md
@@ -62,6 +62,24 @@ C:\Python313\python.exe -m pre_commit run --all-files
 C:\Python313\python.exe -m pre_commit run --files path/to/file.cpp path/to/another_file.gd
 ```
 
+## Commit/push quality gate (required)
+
+Before any commit/push flow:
+
+1. Run pre-commit (all files for broad changes, targeted files for narrow fixes).
+2. Run the most relevant tests for changed areas (if tests exist).
+3. Run at least one build command when C++/build logic changed.
+4. If hooks modify files during `git commit`, re-stage and commit again.
+5. Do not bypass hooks with `--no-verify` in normal development.
+
+Recommended terminal sequence:
+
+```powershell
+C:\Python313\python.exe -m pre_commit run --files <changed-file-1> <changed-file-2>
+# Optional broader validation when scope is wide:
+C:\Python313\python.exe -m pre_commit run --all-files
+```
+
 ## Validation checklist
 
 When the user asks to validate or check their work:

--- a/.github/skills/focus/SKILL.md
+++ b/.github/skills/focus/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: focus
+description: Resume current work, check active task status, start a new task, or mark a task complete. Use when user says resume, what am I working on, task done, pick next task, update checkpoint, what's my focus, or starts a new session.
+---
+
+# Focus — Phoenix Agentic Engine
+
+## Mandatory first step
+
+Always read the current task file before doing anything else:
+
+```
+read_file(".github/context/CURRENT_TASK.md")
+```
+
+## Workflows
+
+### Resume (user says "resume", "what am I working on?", or starts a new session)
+
+1. Read `.github/context/CURRENT_TASK.md`
+2. If a task is active: summarize the current task in 3 lines — what, last checkpoint, next step
+3. If no active task: say "No active task" and offer to pick the next one
+
+### Pick next task (user says "pick next task", "what should I work on?")
+
+1. Read `.github/context/CURRENT_TASK.md` — confirm no active task (or ask to close current one first)
+2. Read the roadmap docs:
+   - `phoenix_docs_private/ROADMAP.md`
+   - `.github/instructions/engine-private-roadmap.instructions.md`
+3. Check the project board for items in "Ready" or "Backlog" for this repo using GitHub MCP tools:
+   - `mcp_github_github_list_issues` for `rivie13/Phoenix-Agentic-Engine`
+4. Recommend the highest-priority unblocked task based on: phase order, dependencies resolved, roadmap sequence
+5. Ask user to confirm
+6. Create a GitHub issue if one doesn't exist
+7. Fill in `.github/context/CURRENT_TASK.md` with the task details
+8. Move the issue to "In Progress" on the project board
+
+### Update checkpoint (user says "save progress", "checkpoint", "update task")
+
+1. Read `.github/context/CURRENT_TASK.md`
+2. Ask what was accomplished and what's next
+3. Update the "Last checkpoint" and "Next step" fields
+4. Commit the updated CURRENT_TASK.md
+
+### Complete task (user says "task done", "finished", "close task")
+
+1. Read `.github/context/CURRENT_TASK.md`
+2. Verify acceptance criteria are met
+3. Move the issue to "Done" on the project board (or "In Review" if PR is open)
+4. Reset `.github/context/CURRENT_TASK.md` to the "no active task" state
+5. Commit the reset
+6. Offer to pick the next task
+
+## Cross-repo awareness
+
+This is the **Engine** repo (Godot fork). Related repos:
+- Backend: `rivie13/Phoenix-Agentic-Engine-Backend`
+- Interface: `rivie13/Phoenix-Agentic-Engine-Interface`
+
+If the current task has cross-repo dependencies, note them in the "Depends on" field.
+
+## Project board
+
+- **Board URL:** https://github.com/users/rivie13/projects/3
+- **Columns:** Backlog → Ready → In Progress → In Review → Done
+
+## Privacy rules
+
+This repo is **public**. When writing to CURRENT_TASK.md:
+- Do NOT include API keys, secrets, or credentials
+- Do NOT include private strategy details
+- Keep descriptions technical and public-safe

--- a/.github/skills/focus/SKILL.md
+++ b/.github/skills/focus/SKILL.md
@@ -64,11 +64,27 @@ read_file(".github/context/CURRENT_TASK.md")
 
 Use sub-issues for structured work. See `.github/docs/PROJECT_WORKFLOW.md` for full details.
 
-- **Epic** (label: `epic`) — Multi-repo milestone, spans weeks–months
-- **Feature** (label: `feature`) — Single-repo deliverable, days–weeks
-- **Task** (label: `task`) — Single PR unit of work, hours–days
+- **Epic** (label: `epic`) — Multi-PR milestone, maps to a `feature/*` branch, spans weeks–months
+- **Feature** (label: `feature`) — Single-repo deliverable, days–weeks (may also map to a `feature/*` branch)
+- **Task** (label: `task`) — Single PR unit of work, maps to a `subfeature/task/<desc>` branch, hours–days
+- **Bug** (label: `bug`) — Maps to a `subfeature/bugfix/<desc>` branch
+- **Refactor/Test/Docs/Chore** — Maps to `subfeature/<type>/<desc>` branches
 
 Sub-issues can cross repos. An Engine Epic can have Backend or Interface sub-issues.
+
+### Issue–branch mapping
+
+| Issue type | Branch pattern | PR target |
+|------------|---------------|-----------|
+| Epic | `feature/<topic>` | `main` |
+| Task | `subfeature/task/<desc>` | parent `feature/*` |
+| Bug | `subfeature/bugfix/<desc>` | parent `feature/*` |
+| Refactor | `subfeature/refactor/<desc>` | parent `feature/*` |
+| Test | `subfeature/test/<desc>` | parent `feature/*` |
+| Docs | `subfeature/docs/<desc>` | parent `feature/*` |
+| Chore | `subfeature/chore/<desc>` | parent `feature/*` |
+
+When picking a task, identify which epic/feature branch it belongs to and branch from that feature branch.
 
 ## Cross-repo awareness
 

--- a/.github/skills/focus/SKILL.md
+++ b/.github/skills/focus/SKILL.md
@@ -51,6 +51,25 @@ read_file(".github/context/CURRENT_TASK.md")
 5. Commit the reset
 6. Offer to pick the next task
 
+### Assign to Copilot cloud agent (user says "assign to copilot", "cloud agent this")
+
+1. Confirm the issue is well-scoped with clear acceptance criteria
+2. Add the `cloud-agent` label to the issue
+3. The `cloud-agent-assign.yml` workflow will auto-assign Copilot
+4. Set "Work mode" to "Cloud Agent" on the project board
+5. Move board item to "Ready" if not already there
+6. Note in CURRENT_TASK.md that this task is delegated to cloud agent
+
+## Issue hierarchy
+
+Use sub-issues for structured work. See `.github/docs/PROJECT_WORKFLOW.md` for full details.
+
+- **Epic** (label: `epic`) — Multi-repo milestone, spans weeks–months
+- **Feature** (label: `feature`) — Single-repo deliverable, days–weeks
+- **Task** (label: `task`) — Single PR unit of work, hours–days
+
+Sub-issues can cross repos. An Engine Epic can have Backend or Interface sub-issues.
+
 ## Cross-repo awareness
 
 This is the **Engine** repo (Godot fork). Related repos:
@@ -63,6 +82,11 @@ If the current task has cross-repo dependencies, note them in the "Depends on" f
 
 - **Board URL:** https://github.com/users/rivie13/projects/3
 - **Columns:** Backlog → Ready → In Progress → In Review → Done
+
+## Reference docs
+
+- **Full workflow:** `.github/docs/PROJECT_WORKFLOW.md` — Ralph Loop, issue hierarchy, cloud agent flow
+- **Roadmap:** `phoenix_docs_private/ROADMAP.md`
 
 ## Privacy rules
 

--- a/.github/skills/git-hygiene/SKILL.md
+++ b/.github/skills/git-hygiene/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: git-hygiene
+description: Enforce branch hygiene, pre-commit validation, PR setup via GitHub MCP tools, and review follow-up workflow in the Engine repo. Use when user asks about git workflow, PR creation, branch management, or commit hygiene.
+---
+
+# Git Hygiene — Phoenix Agentic Engine
+
+## CLI tool policy (mandatory)
+
+- **NEVER use `gh` CLI** — it is not installed and must not be used.
+- **Always prefer GitHub MCP tools** (`mcp_github_*`) for all GitHub operations.
+- Fall back to terminal `git` commands only for local worktree operations or when MCP tools fail.
+- Do NOT suggest or attempt any `gh` subcommand.
+
+## Mandatory first step: terminal scope check
+
+1. `Set-Location "C:\Users\rivie\vsCodeProjects\Phoenix-Agentic-Engine"`
+2. `Get-Location`
+3. `git rev-parse --show-toplevel`
+4. `git branch --show-current`
+
+## Branch workflow
+
+1. Sync base branch:
+
+```bash
+git checkout feature/agent-backend-integration   # or main
+git pull --rebase origin feature/agent-backend-integration
+```
+
+2. Create focused branch:
+
+```bash
+git checkout -b feature/<short-topic>
+```
+
+3. Keep PR scope single-purpose and small.
+
+## PR size discipline (mandatory)
+
+- Keep PRs small and focused — one logical change per PR.
+- If a feature branch grows large, break it into sub-branches:
+  1. Create sub-branches off the feature branch for discrete pieces of work.
+  2. Open PRs from each sub-branch into the feature branch.
+  3. Once sub-branch PRs are merged into the feature branch, open a single PR from the feature branch into `main`.
+- Target: PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
+- If a PR exceeds this, strongly consider splitting before requesting review.
+
+## Pre-commit quality gate (required)
+
+Run all:
+
+```powershell
+C:\Python313\python.exe -m pre_commit run --all-files
+C:\Python313\python.exe -m SCons platform=windows target=editor d3d12=no
+```
+
+If any command fails, fix before committing.
+
+## Commit workflow
+
+```bash
+git status
+git add <focused file set>
+git commit -m "feat: <short summary>"
+```
+
+Recommended prefixes: `feat`, `fix`, `chore`, `docs`, `test`.
+
+## PR workflow (use GitHub MCP tools — never `gh` CLI)
+
+1. Push branch from terminal:
+
+```bash
+git push -u origin <feature-branch>
+```
+
+2. Create PR via MCP tool:
+
+```text
+mcp_github_github_create_pull_request(owner="rivie13", repo="Phoenix-Agentic-Engine", title="...", body="<detailed description>", head="<branch>", base="feature/agent-backend-integration")
+```
+
+3. Check whether Copilot review already exists for the latest commits:
+
+```text
+mcp_github_github_pull_request_read(method="get_reviews", owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
+```
+
+If Copilot review is missing for the latest commit set, request it:
+
+```text
+mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
+```
+
+4. Read and handle reviews/comments:
+
+```text
+mcp_github_github_pull_request_read(method="get_reviews", owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
+mcp_github_github_pull_request_read(method="get_review_comments", owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
+```
+
+5. Check PR workflow status and fix failures before merge readiness:
+
+```text
+mcp_github_github_actions_list(method="list_workflow_runs", owner="rivie13", repo="Phoenix-Agentic-Engine")
+mcp_github_github_actions_list(method="list_workflow_jobs", owner="rivie13", repo="Phoenix-Agentic-Engine", resource_id="<RUN_ID>")
+```
+
+If any job fails, use the GitHub Actions Debug skill flow to inspect logs, fix root causes, and re-run/recheck.
+
+6. Apply fixes and re-run quality gate.
+
+## Issue creation (public repo rules)
+
+- Create issues using `mcp_github_github_issue_write` — never `gh issue create`.
+- For non-sensitive, public-facing work: assign to Copilot (cloud agent) using `mcp_github_github_assign_copilot_to_issue`.
+- Do NOT create public issues for private/sensitive matters (secrets, auth, proprietary logic, infrastructure, security vulnerabilities).
+- Search for existing issues before creating duplicates using `mcp_github_github_search_issues`.
+
+## Engine-specific checks for PR readiness
+
+- Pre-commit passes
+- SCons build succeeds
+- PR workflow/status checks are green
+- Changes outside `modules/ultimate_ai/` have `CORE_MODIFICATIONS.md` entry
+- No secrets, credentials, or prompt content

--- a/.github/skills/git-hygiene/SKILL.md
+++ b/.github/skills/git-hygiene/SKILL.md
@@ -21,30 +21,66 @@ description: Enforce branch hygiene, pre-commit validation, PR setup via GitHub 
 
 ## Branch workflow
 
-1. Sync base branch:
+### Hierarchy
+
+| Tier | Pattern | Branches from | Merges into |
+|------|---------|---------------|-------------|
+| **main** | `main` | — | — |
+| **feature** | `feature/<topic>` | `main` | `main` |
+| **subfeature** | `subfeature/<type>/<desc>` | parent `feature/*` | parent `feature/*` |
+
+### Starting a feature
 
 ```bash
-git checkout feature/agent-backend-integration   # or main
-git pull --rebase origin feature/agent-backend-integration
+git checkout main
+git pull --rebase origin main
+git checkout -b feature/<topic>
 ```
 
-2. Create focused branch:
+### Starting a subfeature (daily work)
 
 ```bash
-git checkout -b feature/<short-topic>
+git checkout feature/<topic>
+git pull --rebase origin feature/<topic>
+git checkout -b subfeature/<type>/<short-description>
 ```
+
+Where `<type>` is one of: `task`, `bugfix`, `refactor`, `test`, `docs`, `chore`.
+
+**Examples:**
+- `subfeature/task/wire-up-assistant-panel`
+- `subfeature/bugfix/fix-panel-null-crash`
+- `subfeature/refactor/extract-message-renderer`
+
+### Subfeature PRs target the feature branch — never `main`
+
+```bash
+# PR: subfeature/task/wire-up-assistant-panel → feature/assistant-panel
+```
+
+### Feature PRs target `main` (when all subfeatures are merged)
+
+```bash
+# PR: feature/assistant-panel → main   (will be large — that is expected)
+```
+
+### Top-level branches (non-feature work)
+
+For small standalone changes: `fix/<topic>`, `chore/<topic>`, `mcp-docs/<topic>` — branch from and merge to `main`.
 
 3. Keep PR scope single-purpose and small.
 
 ## PR size discipline (mandatory)
 
 - Keep PRs small and focused — one logical change per PR.
-- If a feature branch grows large, break it into sub-branches:
-  1. Create sub-branches off the feature branch for discrete pieces of work.
-  2. Open PRs from each sub-branch into the feature branch.
-  3. Once sub-branch PRs are merged into the feature branch, open a single PR from the feature branch into `main`.
-- Target: PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
-- If a PR exceeds this, strongly consider splitting before requesting review.
+- **Subfeature → feature PRs** are the normal unit of review.
+- **Feature → main PRs** will be large — that is expected.
+- Break work into subfeature branches early:
+  1. Create `subfeature/<type>/<description>` branches off the parent `feature/*` branch.
+  2. Open PRs from each subfeature branch into the `feature/*` branch.
+  3. Once all subfeature PRs are merged, open a single PR from `feature/*` into `main`.
+- Target: subfeature PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
+- If a subfeature PR exceeds this, strongly consider splitting before requesting review.
 
 ## Pre-commit quality gate (required)
 
@@ -117,6 +153,13 @@ If any job fails, use the GitHub Actions Debug skill flow to inspect logs, fix r
 - For non-sensitive, public-facing work: assign to Copilot (cloud agent) using `mcp_github_github_assign_copilot_to_issue`.
 - Do NOT create public issues for private/sensitive matters (secrets, auth, proprietary logic, infrastructure, security vulnerabilities).
 - Search for existing issues before creating duplicates using `mcp_github_github_search_issues`.
+
+### Issue–branch alignment
+
+- **Epic issues** (label: `epic`) map to `feature/*` branches.
+- **Sub-issues** (labels: `task`, `bug`, `refactor`, `test`, `docs`, `chore`) map to `subfeature/<type>/<desc>` branches.
+- Create sub-issues using `mcp_github_github_sub_issue_write`, linking them to the parent epic.
+- Subfeature PRs reference sub-issues with `Closes #N`. Feature PRs reference the epic with `Closes #N`.
 
 ## Engine-specific checks for PR readiness
 

--- a/.github/skills/github-actions-debug/SKILL.md
+++ b/.github/skills/github-actions-debug/SKILL.md
@@ -24,6 +24,15 @@ description: Debug failed GitHub Actions CI/CD workflow runs. Use when user asks
 | `web_builds.yml` | Upstream Godot Web builds |
 | `ios_builds.yml` | Upstream Godot iOS builds |
 
+## PR gate usage (required)
+
+During PR work, treat failed GitHub Actions checks as a merge blocker:
+
+1. Inspect failed runs for the PR.
+2. Triage root cause using logs.
+3. Fix issues locally and re-validate (`pre_commit` + relevant tests/build).
+4. Push and confirm checks recover.
+
 ## Debugging Workflow: Step-by-step
 
 ### Step 1: List recent workflow runs

--- a/.github/skills/github-code-review/SKILL.md
+++ b/.github/skills/github-code-review/SKILL.md
@@ -21,41 +21,46 @@ If the user doesn't specify a PR number, list open PRs:
 mcp_github_github_list_pull_requests(owner="rivie13", repo="Phoenix-Agentic-Engine", state="open")
 ```
 
-### Step 2: Get review comments
+### Step 2: Load PR details/comments with MCP PR tools
 
-Fetch review threads (which include resolved/unresolved status):
+Use PR management tools to inspect the active/open PR (files, reviews, comments, checks):
 
-```
-mcp_github_github_pull_request_read(method="get_review_comments", owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
-```
+1. Activate PR management tools.
+2. Retrieve the active/open PR details and comments.
+3. Use those comments as the canonical fix list.
 
-Also get the list of reviews to understand overall review status:
-
-```
-mcp_github_github_pull_request_read(method="get_reviews", owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
-```
-
-### Step 3: Get changed files for context
-
-```
-mcp_github_github_pull_request_read(method="get_files", owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
-```
-
-### Step 4: Address each unresolved comment
+### Step 3: Address each unresolved comment
 
 For each unresolved review thread:
 1. Read the file and surrounding context using `read_file`
 2. Understand the reviewer's concern
 3. Make the fix using file edit tools
-4. Report what was changed and why
+4. Re-run pre-commit + relevant tests
+5. Report what was changed and why
 
-### Step 5: Request a new review (optional)
+### Step 3b: Check PR workflows and fix CI failures
+
+After pushing review fixes:
+
+1. Check PR status checks and workflow runs.
+2. If any workflow fails, use the `github-actions-debug` skill to investigate logs.
+3. Apply fixes, re-run local validation, and push again.
+4. Repeat until required checks are green.
+
+### Step 4: Request a new review (optional)
 
 After addressing all comments, the user may want to request a re-review:
 
 ```
 mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
 ```
+
+## Copilot review resolution loop (required)
+
+- Treat Copilot comments like any other review: fix, validate, push.
+- Prefer small, focused commits per feedback batch.
+- Run `pre_commit` and relevant tests before pushing each fix batch.
+- If a comment is not actioned, reply with rationale in the PR.
 
 ## Workflow: Request a Copilot Code Review
 

--- a/.github/skills/github-code-review/SKILL.md
+++ b/.github/skills/github-code-review/SKILL.md
@@ -51,6 +51,9 @@ After pushing review fixes:
 
 After addressing all comments, the user may want to request a re-review:
 
+- First check if a Copilot review is already present/recent on the PR.
+- Only request if none exists for the current change batch, or if user explicitly asks for another pass.
+
 ```
 mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
 ```
@@ -65,6 +68,9 @@ mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-
 ## Workflow: Request a Copilot Code Review
 
 To request an automated Copilot code review on a PR:
+
+- Treat Copilot reviews as expensive; request sparingly.
+- Default policy: one request per PR unless explicitly needed.
 
 ```
 mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)

--- a/.github/skills/github-code-review/SKILL.md
+++ b/.github/skills/github-code-review/SKILL.md
@@ -52,7 +52,7 @@ After pushing review fixes:
 After addressing all comments, the user may want to request a re-review:
 
 - First check if a Copilot review is already present/recent on the PR.
-- Only request if none exists for the current change batch, or if user explicitly asks for another pass.
+- Only request if none exists for the latest commit set, or if the user explicitly asks for another pass.
 
 ```
 mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
@@ -65,12 +65,13 @@ mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-
 - Run `pre_commit` and relevant tests before pushing each fix batch.
 - If a comment is not actioned, reply with rationale in the PR.
 
-## Workflow: Request a Copilot Code Review
+## Workflow: Request a Copilot Code Review (manual fallback)
 
-To request an automated Copilot code review on a PR:
+If a Copilot review is missing for the latest commit set on a PR:
 
-- Treat Copilot reviews as expensive; request sparingly.
-- Default policy: one request per PR unless explicitly needed.
+- Copilot review is expected to auto-trigger when available.
+- Do not request manually if a Copilot review already exists for the latest commit set.
+- Request manually only when missing for the latest commit set.
 
 ```
 mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)

--- a/.github/skills/load-engine-instructions/SKILL.md
+++ b/.github/skills/load-engine-instructions/SKILL.md
@@ -27,7 +27,7 @@ All files live in `Phoenix-Agentic-Engine/.github/instructions/`:
 | File | Content | When to load |
 |------|---------|-------------|
 | `engine-coding-conventions.instructions.md` | C++ style, Godot patterns, naming | When writing or reviewing code |
-| `engine-build-and-test.instructions.md` | SCons build, pre-commit, validation | When building, testing, or fixing build errors |
+| `engine-build-and-test.instructions.md` | SCons build, pre-commit, validation, git hygiene gates | When building, testing, validating, or preparing commits |
 | `engine-project-structure.instructions.md` | Directory layout, module organization | When navigating the codebase or adding new files |
 | `engine-private-architecture.instructions.md` | Brain-Body split, module internals | When making architectural decisions |
 | `engine-private-roadmap.instructions.md` | Phase plan, integrations, milestones | When planning work or checking status |
@@ -43,6 +43,12 @@ Read the files you need using `read_file`. Common patterns:
 ```
 read_file("Phoenix-Agentic-Engine/.github/instructions/engine-coding-conventions.instructions.md")
 read_file("Phoenix-Agentic-Engine/.github/instructions/engine-project-structure.instructions.md")
+```
+
+For commit/push preparation, also load:
+
+```
+read_file("Phoenix-Agentic-Engine/.github/instructions/engine-build-and-test.instructions.md")
 ```
 
 ### Build/test troubleshooting

--- a/.github/skills/pr-management/SKILL.md
+++ b/.github/skills/pr-management/SKILL.md
@@ -114,7 +114,7 @@ mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-
 2. Apply fixes in focused commits.
 3. Re-run pre-commit + relevant tests.
 4. Push updates to the same PR branch.
-5. Request Copilot re-review if needed.
+5. Request Copilot re-review only if needed and missing for the latest commit set.
 
 ## Update PR Branch (rebase/merge from base)
 

--- a/.github/skills/pr-management/SKILL.md
+++ b/.github/skills/pr-management/SKILL.md
@@ -9,7 +9,23 @@ description: Create, update, and manage GitHub pull requests across Phoenix repo
 
 - **Owner**: `rivie13`
 - **Repo**: `Phoenix-Agentic-Engine`
-- **Default branch**: `main`
+- **Canonical integration base**: `feature/agent-backend-integration` (unless user specifies another base)
+
+## Branch hygiene (required)
+
+1. Start from the latest target base branch.
+2. Create a focused topic branch (`feature/*`, `fix/*`, `mcp-docs/*`, etc.).
+3. Keep PR scope narrow; avoid unrelated file changes.
+4. Run pre-commit + relevant tests before push.
+5. Never force-push shared branches unless explicitly coordinated.
+
+Example setup:
+
+```bash
+git checkout feature/agent-backend-integration
+git pull --rebase origin feature/agent-backend-integration
+git checkout -b <topic-branch>
+```
 
 ## Create a Pull Request
 
@@ -18,7 +34,8 @@ description: Create, update, and manage GitHub pull requests across Phoenix repo
 Look for a PR template before creating:
 
 ```
-mcp_github_github_get_file_contents(owner="rivie13", repo="Phoenix-Agentic-Engine", path=".github/PULL_REQUEST_TEMPLATE.md")
+file_search(".github/PULL_REQUEST_TEMPLATE*.md")
+file_search(".github/PULL_REQUEST_TEMPLATE/**")
 ```
 
 Also check `.github/PULL_REQUEST_TEMPLATE/` directory.
@@ -27,7 +44,15 @@ Also check `.github/PULL_REQUEST_TEMPLATE/` directory.
 
 Use `get_changed_files` to see what's modified.
 
-### Step 3: Create the PR
+### Step 3: Push and create the PR with MCP tools
+
+Push branch from terminal:
+
+```bash
+git push -u origin <feature-branch>
+```
+
+Create PR via MCP tool:
 
 ```
 mcp_github_github_create_pull_request(
@@ -36,7 +61,7 @@ mcp_github_github_create_pull_request(
   title="<descriptive title>",
   body="<use template if found>",
   head="<feature-branch>",
-  base="main"
+  base="feature/agent-backend-integration"
 )
 ```
 
@@ -45,6 +70,7 @@ mcp_github_github_create_pull_request(
 - What was run/tested
 - Platform tested on
 - If core files changed: justification and `CORE_MODIFICATIONS.md` entry
+- Pre-commit/test commands run and outcomes
 
 ## List Open PRs
 
@@ -55,14 +81,33 @@ mcp_github_github_list_pull_requests(owner="rivie13", repo="Phoenix-Agentic-Engi
 ## Check PR Status
 
 ```
-mcp_github_github_pull_request_read(method="get", owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
+mcp_github_github_list_pull_requests(owner="rivie13", repo="Phoenix-Agentic-Engine", state="open")
+# or use active/open PR management tools for deeper status/details
 ```
+
+## PR CI/workflow gate (required)
+
+After PR creation and after each push:
+
+1. Check PR status checks and workflow runs.
+2. If any GitHub Actions run fails, use the `github-actions-debug` skill to triage logs and root cause.
+3. Fix failures in code/workflow as needed.
+4. Re-run pre-commit + relevant tests locally.
+5. Push fixes and re-check until required checks pass.
 
 ## Request Copilot Review
 
 ```
 mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
 ```
+
+## After review feedback
+
+1. Fetch review comments/status.
+2. Apply fixes in focused commits.
+3. Re-run pre-commit + relevant tests.
+4. Push updates to the same PR branch.
+5. Request Copilot re-review if needed.
 
 ## Update PR Branch (rebase/merge from base)
 

--- a/.github/skills/pr-management/SKILL.md
+++ b/.github/skills/pr-management/SKILL.md
@@ -97,6 +97,13 @@ After PR creation and after each push:
 
 ## Request Copilot Review
 
+Policy:
+
+1. Copilot review should happen automatically for new PRs.
+2. Before requesting, check whether Copilot review was already requested/completed for that PR.
+3. If already present, do not request again by default (cost control).
+4. Request another round only when the user explicitly asks or when substantial new changes were pushed and no recent Copilot pass exists.
+
 ```
 mcp_github_github_request_copilot_review(owner="rivie13", repo="Phoenix-Agentic-Engine", pullNumber=<PR_NUMBER>)
 ```

--- a/.github/skills/pr-management/SKILL.md
+++ b/.github/skills/pr-management/SKILL.md
@@ -16,33 +16,57 @@ description: Create, update, and manage GitHub pull requests across Phoenix repo
 
 - **Owner**: `rivie13`
 - **Repo**: `Phoenix-Agentic-Engine`
-- **Canonical integration base**: `feature/agent-backend-integration` (unless user specifies another base)
+- **Canonical integration base**: Determined by branch tier:
+  - Subfeature branches → parent `feature/*` branch
+  - Feature branches → `main`
+  - Standalone fix/chore branches → `main`
 
 ## Branch hygiene (required)
 
-1. Start from the latest target base branch.
-2. Create a focused topic branch (`feature/*`, `fix/*`, `mcp-docs/*`, etc.).
+### Hierarchy
+
+| Tier | Pattern | Branches from | Merges into |
+|------|---------|---------------|-------------|
+| **main** | `main` | — | — |
+| **feature** | `feature/<topic>` | `main` | `main` |
+| **subfeature** | `subfeature/<type>/<desc>` | parent `feature/*` | parent `feature/*` |
+
+Subfeature `<type>` values: `task`, `bugfix`, `refactor`, `test`, `docs`, `chore`.
+
+1. Start from the latest target base branch (feature branch for subfeatures, main for features).
+2. Create a focused topic branch with the appropriate naming convention.
 3. Keep PR scope narrow; avoid unrelated file changes.
 4. Run pre-commit + relevant tests before push.
 5. Never force-push shared branches unless explicitly coordinated.
+6. **Subfeature PRs MUST target their parent `feature/*` branch** — never `main`.
 
 ## PR size discipline (mandatory)
 
 - Keep PRs small and focused — one logical change per PR.
-- If a feature branch grows large, break it into sub-branches:
-  1. Create sub-branches off the feature branch for discrete pieces of work.
-  2. Open PRs from each sub-branch into the feature branch.
-  3. Once sub-branch PRs are merged into the feature branch, open a single PR from the feature branch into `main`.
-- Target: PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
-- If a PR exceeds this, strongly consider splitting before requesting review.
+- **Subfeature → feature PRs** are the normal unit of review.
+- **Feature → main PRs** will be large (accumulating all merged subfeature work). This is expected.
+- Break work into subfeature branches early:
+  1. Create `subfeature/<type>/<description>` branches off the parent `feature/*` branch.
+  2. Open PRs from each subfeature branch into the `feature/*` branch.
+  3. Once all subfeature PRs are merged, open a single PR from `feature/*` into `main`.
+- Target: subfeature PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
+- If a subfeature PR exceeds this, strongly consider splitting before requesting review.
 - Never let PRs accumulate dozens of unrelated changes.
 
-Example setup:
+Example setup (subfeature workflow):
 
 ```bash
-git checkout feature/agent-backend-integration
-git pull --rebase origin feature/agent-backend-integration
-git checkout -b <topic-branch>
+git checkout feature/assistant-panel
+git pull --rebase origin feature/assistant-panel
+git checkout -b subfeature/task/wire-up-panel-shell
+```
+
+Example setup (feature workflow):
+
+```bash
+git checkout main
+git pull --rebase origin main
+git checkout -b feature/assistant-panel
 ```
 
 ## Create a Pull Request
@@ -78,8 +102,8 @@ mcp_github_github_create_pull_request(
   repo="Phoenix-Agentic-Engine",
   title="<descriptive title>",
   body="<use template if found>",
-  head="<feature-branch>",
-  base="feature/agent-backend-integration"
+  head="<branch-name>",
+  base="<parent branch>"   # feature/* for subfeatures, main for features
 )
 ```
 
@@ -156,8 +180,10 @@ mcp_github_github_push_files(
 
 ## Branch conventions
 
-- `feature/<name>` — new features
-- `fix/<name>` — bug fixes
+- `feature/<name>` — new features (branches from `main`, merges to `main`)
+- `subfeature/<type>/<name>` — work within a feature (branches from `feature/*`, merges to `feature/*`)
+  - Types: `task`, `bugfix`, `refactor`, `test`, `docs`, `chore`
+- `fix/<name>` — standalone bug fixes (branches from `main`)
 - `upstream-sync` — reserved for upstream Godot sync
 
 ## Issue creation (public repo — never use `gh` CLI)
@@ -167,3 +193,10 @@ mcp_github_github_push_files(
 - Do NOT create public issues for private/sensitive matters (secrets, auth, proprietary logic, security vulnerabilities).
 - Search for existing issues before creating duplicates using `mcp_github_github_search_issues`.
 - Use issues to break large features into smaller, trackable units of work.
+
+### Issue–branch alignment
+
+- **Epic issues** (label: `epic`) map to `feature/*` branches.
+- **Sub-issues** (labels: `task`, `bug`, `refactor`, `test`, `docs`, `chore`) map to `subfeature/<type>/<desc>` branches.
+- Create sub-issues using `mcp_github_github_sub_issue_write`, linking them to the parent epic.
+- Subfeature PRs reference sub-issues with `Closes #N`. Feature PRs reference the epic with `Closes #N`.

--- a/.github/skills/pr-management/SKILL.md
+++ b/.github/skills/pr-management/SKILL.md
@@ -5,6 +5,13 @@ description: Create, update, and manage GitHub pull requests across Phoenix repo
 
 # PR Management — Phoenix Agentic Engine
 
+## CLI tool policy (mandatory)
+
+- **NEVER use `gh` CLI** — it is not installed and must not be used.
+- **Always prefer GitHub MCP tools** (`mcp_github_*`) for all GitHub operations.
+- Fall back to terminal `git` commands only for local worktree operations or when MCP tools fail.
+- Do NOT suggest or attempt any `gh` subcommand.
+
 ## Repo Context
 
 - **Owner**: `rivie13`
@@ -18,6 +25,17 @@ description: Create, update, and manage GitHub pull requests across Phoenix repo
 3. Keep PR scope narrow; avoid unrelated file changes.
 4. Run pre-commit + relevant tests before push.
 5. Never force-push shared branches unless explicitly coordinated.
+
+## PR size discipline (mandatory)
+
+- Keep PRs small and focused — one logical change per PR.
+- If a feature branch grows large, break it into sub-branches:
+  1. Create sub-branches off the feature branch for discrete pieces of work.
+  2. Open PRs from each sub-branch into the feature branch.
+  3. Once sub-branch PRs are merged into the feature branch, open a single PR from the feature branch into `main`.
+- Target: PRs should ideally be under ~400 lines of meaningful change (excluding generated files, lock files, submodule pointer updates).
+- If a PR exceeds this, strongly consider splitting before requesting review.
+- Never let PRs accumulate dozens of unrelated changes.
 
 Example setup:
 
@@ -66,9 +84,11 @@ mcp_github_github_create_pull_request(
 ```
 
 ### PR description should include (per repo conventions):
-- What was built/changed
-- What was run/tested
-- Platform tested on
+- **Summary**: What was built/changed and why
+- **Changes**: Bullet list of key changes
+- **Testing**: What was run/tested, platform, and pass/fail results
+- **Breaking changes**: Any upstream-merge or compatibility concerns
+- **Related issues**: Link related issues with `Closes #N` or `Relates to #N`
 - If core files changed: justification and `CORE_MODIFICATIONS.md` entry
 - Pre-commit/test commands run and outcomes
 
@@ -139,3 +159,11 @@ mcp_github_github_push_files(
 - `feature/<name>` — new features
 - `fix/<name>` — bug fixes
 - `upstream-sync` — reserved for upstream Godot sync
+
+## Issue creation (public repo — never use `gh` CLI)
+
+- Create issues using `mcp_github_github_issue_write`.
+- For non-sensitive, public-facing work: assign to Copilot (cloud agent) using `mcp_github_github_assign_copilot_to_issue`.
+- Do NOT create public issues for private/sensitive matters (secrets, auth, proprietary logic, security vulnerabilities).
+- Search for existing issues before creating duplicates using `mcp_github_github_search_issues`.
+- Use issues to break large features into smaller, trackable units of work.

--- a/.github/skills/update-copilot-instructions/SKILL.md
+++ b/.github/skills/update-copilot-instructions/SKILL.md
@@ -34,6 +34,7 @@ description: Update Copilot instruction files to reflect current project state, 
 - Client/backend boundary shifted? → Update `engine-private-strategy.instructions.md`
 - Review priorities changed? → Update `engine-code-review.instructions.md`
 - Git/branch/pre-commit workflow changed? → Update `engine-build-and-test.instructions.md`, `engine-coding-conventions.instructions.md`, and relevant skills (`build-and-test`, `pr-management`, `github-code-review`)
+- Copilot review request policy changed? → Update `engine-code-review.instructions.md` + `pr-management`/`github-code-review` skills with one-request-per-PR cost controls.
 
 ### Step 2: Read the current file and update it
 

--- a/.github/skills/update-copilot-instructions/SKILL.md
+++ b/.github/skills/update-copilot-instructions/SKILL.md
@@ -33,10 +33,17 @@ description: Update Copilot instruction files to reflect current project state, 
 - Conventions changed? → Update `engine-coding-conventions.instructions.md`
 - Client/backend boundary shifted? → Update `engine-private-strategy.instructions.md`
 - Review priorities changed? → Update `engine-code-review.instructions.md`
+- Git/branch/pre-commit workflow changed? → Update `engine-build-and-test.instructions.md`, `engine-coding-conventions.instructions.md`, and relevant skills (`build-and-test`, `pr-management`, `github-code-review`)
 
 ### Step 2: Read the current file and update it
 
 Use `read_file` to load, then edit with current state.
+
+If workflow behavior changes, keep these three layers aligned in the same PR when possible:
+
+1. Contributor docs (`README.md` and/or `CONTRIBUTING.md`)
+2. Instruction files (`.github/instructions/*.instructions.md`)
+3. Skills (`.github/skills/*/SKILL.md`)
 
 ### Step 3: Keep instructions concise
 

--- a/.github/workflows/cloud-agent-assign.yml
+++ b/.github/workflows/cloud-agent-assign.yml
@@ -1,0 +1,121 @@
+# Securely assign Copilot coding agent when the `cloud-agent` label is added.
+# Optional hardening: set repository variable CLOUD_AGENT_ALLOWED_USERS (comma-separated usernames).
+# If set, actor must be in this allowlist AND have write/maintain/admin permission.
+
+name: Assign Copilot Cloud Agent
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  assign-copilot:
+    if: github.event.label.name == 'cloud-agent'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+      actions: read
+    steps:
+      - name: Validate delegator permissions
+        id: guard
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const actor = context.actor;
+
+            let permission = 'none';
+            try {
+              const permissionResp = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: actor,
+              });
+              permission = permissionResp.data.permission;
+            } catch (error) {
+              permission = 'none';
+            }
+
+            const allowedByPermission = ['admin', 'maintain', 'write'].includes(permission);
+
+            let allowlistRaw = '';
+            try {
+              const variableResp = await github.rest.actions.getRepoVariable({
+                owner,
+                repo,
+                name: 'CLOUD_AGENT_ALLOWED_USERS',
+              });
+              allowlistRaw = variableResp.data.value || '';
+            } catch (error) {
+              allowlistRaw = '';
+            }
+
+            const allowlist = (allowlistRaw || '')
+              .split(',')
+              .map((entry) => entry.trim())
+              .filter(Boolean);
+            const allowedByAllowlist = allowlist.length === 0 ? true : allowlist.includes(actor);
+
+            const allowed = allowedByPermission && allowedByAllowlist;
+
+            core.setOutput('allowed', String(allowed));
+            core.setOutput('permission', permission);
+            core.setOutput('allowlistEnabled', String(allowlist.length > 0));
+
+      - name: Reject unauthorized delegation
+        if: steps.guard.outputs.allowed != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            const actor = context.actor;
+            const permission = '${{ steps.guard.outputs.permission }}';
+            const allowlistEnabled = '${{ steps.guard.outputs.allowlistEnabled }}' === 'true';
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number,
+                name: 'cloud-agent',
+              });
+            } catch (error) {
+            }
+
+            const reason = allowlistEnabled
+              ? `@${actor} is not authorized by CLOUD_AGENT_ALLOWED_USERS or lacks required repository permission.`
+              : `@${actor} has '${permission}' permission; write/maintain/admin is required to delegate to Copilot.`;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `⛔ Cloud-agent delegation blocked. ${reason}`,
+            });
+
+      - name: Assign @copilot
+        if: steps.guard.outputs.allowed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number,
+              assignees: ['copilot'],
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: '🤖 Copilot coding agent has been assigned via the `cloud-agent` label.',
+            });

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -1,0 +1,17 @@
+name: Sync to Project Board
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to Phoenix Project Board
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/rivie13/projects/3
+          github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -146,39 +146,39 @@ jobs:
             fi
           done
 
-              if [ ! -f "./bin/phoenix_web_capabilities.json" ]; then
-              echo "Missing MVP capability manifest: ./bin/phoenix_web_capabilities.json" >&2
-              ls -la ./bin || true
-              exit 1
-              fi
+          if [ ! -f "./bin/phoenix_web_capabilities.json" ]; then
+            echo "Missing MVP capability manifest: ./bin/phoenix_web_capabilities.json" >&2
+            ls -la ./bin || true
+            exit 1
+          fi
 
-              python3 - <<'PY'
-              import json
-              from pathlib import Path
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
 
-              manifest_path = Path("./bin/phoenix_web_capabilities.json")
-              data = json.loads(manifest_path.read_text(encoding="utf-8"))
+          manifest_path = Path("./bin/phoenix_web_capabilities.json")
+          data = json.loads(manifest_path.read_text(encoding="utf-8"))
 
-              if data.get("schema_version") != "v1":
-                raise SystemExit("Invalid schema_version in phoenix_web_capabilities.json")
-              if data.get("profile") != "web_mvp_chat_pixelpen":
-                raise SystemExit("Invalid profile in phoenix_web_capabilities.json")
+          if data.get("schema_version") != "v1":
+              raise SystemExit("Invalid schema_version in phoenix_web_capabilities.json")
+          if data.get("profile") != "web_mvp_chat_pixelpen":
+              raise SystemExit("Invalid profile in phoenix_web_capabilities.json")
 
-              capabilities = data.get("capabilities")
-              if not isinstance(capabilities, dict):
-                raise SystemExit("Missing capabilities object in phoenix_web_capabilities.json")
+          capabilities = data.get("capabilities")
+          if not isinstance(capabilities, dict):
+              raise SystemExit("Missing capabilities object in phoenix_web_capabilities.json")
 
-              required_true = ["assistant_chat", "pixelpen"]
-              required_false = ["gdterm", "git_plugin", "diff_margin", "bfxr", "gut"]
+          required_true = ["assistant_chat", "pixelpen"]
+          required_false = ["gdterm", "git_plugin", "diff_margin", "bfxr", "gut"]
 
-              for key in required_true:
-                if capabilities.get(key) is not True:
+          for key in required_true:
+              if capabilities.get(key) is not True:
                   raise SystemExit(f"Expected capabilities.{key}=true in phoenix_web_capabilities.json")
 
-              for key in required_false:
-                if capabilities.get(key) is not False:
+          for key in required_false:
+              if capabilities.get(key) is not False:
                   raise SystemExit(f"Expected capabilities.{key}=false in phoenix_web_capabilities.json")
-              PY
+          PY
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact

--- a/.gitignore
+++ b/.gitignore
@@ -226,7 +226,8 @@ cscope.po.out
 *.swp
 
 # Visual Studio Code
-.vscode/
+.vscode/*
+!.vscode/tasks.json
 *.code-workspace
 .history/
 

--- a/.gitignore
+++ b/.gitignore
@@ -391,7 +391,8 @@ cpp.hint
 .DS_Store
 __MACOSX
 Godot.app
-
+# Agent prompts (private, never commit)
+prompts/
 # Windows
 # https://github.com/github/gitignore/blob/main/Global/Windows.gitignore
 [Tt]humbs.db

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "modules/ultimate_ai/external/gut"]
 	path = modules/ultimate_ai/external/gut
 	url = https://github.com/rivie13/GUT-Godot-Unit-Test.git
+[submodule "modules/ultimate_ai/external/godot-mcp-docs"]
+	path = modules/ultimate_ai/external/godot-mcp-docs
+	url = https://github.com/rivie13/godot-mcp-docs.git

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,111 @@
+{
+  "version": "2.0.0",
+  "inputs": [
+    {
+      "id": "publicGatewayUrl",
+      "type": "promptString",
+      "description": "Public Gateway URL (cloudflared/App Service)",
+      "default": "https://ensures-strap-tracy-constitution.trycloudflare.com"
+    }
+  ],
+  "tasks": [
+    {
+      "label": "dev: build editor",
+      "type": "shell",
+      "command": "C:\\Python313\\python.exe",
+      "args": [
+        "-m",
+        "SCons",
+        "platform=windows",
+        "target=editor",
+        "d3d12=no",
+        "module_ultimate_ai_enabled=yes",
+        "dev_build=yes"
+      ],
+      "group": "build"
+    },
+    {
+      "label": "dev: run editor (env)",
+      "type": "shell",
+      "command": ".\\scripts\\run-editor-with-env.ps1",
+      "group": "build"
+    },
+    {
+      "label": "dev: verify: headless:version",
+      "type": "shell",
+      "command": ".\\scripts\\validate-editor-headless.ps1",
+      "args": [
+        "-Action",
+        "version"
+      ],
+      "group": "test"
+    },
+    {
+      "label": "dev: verify: headless:startup",
+      "type": "shell",
+      "command": ".\\scripts\\validate-editor-headless.ps1",
+      "args": [
+        "-Action",
+        "startup"
+      ],
+      "group": "test"
+    },
+    {
+      "label": "dev: verify: headless:doctool-temp",
+      "type": "shell",
+      "command": ".\\scripts\\validate-editor-headless.ps1",
+      "args": [
+        "-Action",
+        "doctool-temp"
+      ],
+      "group": "test"
+    },
+    {
+      "label": "dev: verify: check",
+      "type": "shell",
+      "command": ".\\scripts\\validate-editor-headless.ps1",
+      "args": [
+        "-Action",
+        "all"
+      ],
+      "dependsOn": [
+        "dev: build editor"
+      ],
+      "dependsOrder": "sequence",
+      "group": "test"
+    },
+    {
+      "label": "dev: verify: check (full)",
+      "type": "shell",
+      "command": ".\\scripts\\validate-editor-headless.ps1",
+      "args": [
+        "-Action",
+        "all-full"
+      ],
+      "dependsOn": [
+        "dev: build editor"
+      ],
+      "dependsOrder": "sequence",
+      "group": "test"
+    },
+    {
+      "label": "dev: tunnel:set-public-url",
+      "type": "shell",
+      "command": ".\\scripts\\set-public-gateway-url.ps1",
+      "args": [
+        "-Url",
+        "${input:publicGatewayUrl}"
+      ]
+    },
+    {
+      "label": "dev: tunnel:show-config",
+      "type": "shell",
+      "command": ".\\scripts\\show-public-gateway-url.ps1"
+    },
+    {
+      "label": "dev: tunnel:sync-from-backend",
+      "type": "shell",
+      "command": ".\\scripts\\sync-public-gateway-url-from-backend.ps1"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,14 @@ stable state, i.e. if your first commit has a bug that you fixed in the second
 commit, try to merge them together before making your pull request. This
 includes fixing build issues or typos, adding documentation, etc.
 
+For Phoenix-specific workflow hygiene in this fork:
+
+- Use terminal Git commands for commit/push so local hooks run (`git add`, `git commit`, `git push`).
+- Do not bypass hooks with `--no-verify` in normal development.
+- Run pre-commit before push (`C:\Python313\python.exe -m pre_commit run --all-files` or `--files ...`).
+- If hooks rewrite files during commit, re-stage and commit again.
+- Run relevant tests/build checks for changed areas before opening/updating a PR.
+
 See our [PR workflow](https://contributing.godotengine.org/en/latest/organization/pull_requests/creating_pull_requests.html)
 documentation for tips on using Git, amending commits and rebasing branches.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ For this fork, we use a terminal-first Git workflow so local hooks run consisten
   - or `C:\Python313\python.exe -m pre_commit run --files <file1> <file2>`
 - If hooks modify files during commit, re-stage and commit again.
 
+### Phoenix extra validation tasks (separate from pre-commit)
+
+Before commit/push, run these VS Code tasks in addition to pre-commit:
+
+- `dev: verify: check` (build + headless version/startup smoke checks)
+- Optional deeper check: `dev: verify: check (full)` (adds headless doctool-to-temp validation)
+
+You can also run the individual tasks directly:
+
+- `dev: verify: headless:version`
+- `dev: verify: headless:startup`
+- `dev: verify: headless:doctool-temp`
+
 ## Documentation and demos
 
 The official documentation is hosted on [Read the Docs](https://docs.godotengine.org).

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ The best way to get in touch with the core engine developers is to join the
 To get started contributing to the project, see the [contributing guide](CONTRIBUTING.md).
 This document also includes guidelines for reporting bugs.
 
+### Phoenix git hygiene quick checks
+
+For this fork, we use a terminal-first Git workflow so local hooks run consistently:
+
+- Run `git add` / `git commit` / `git push` from terminal in the repo root.
+- Do not use `--no-verify` for normal commits.
+- Ensure pre-commit passes before push:
+  - `C:\Python313\python.exe -m pre_commit run --all-files`
+  - or `C:\Python313\python.exe -m pre_commit run --files <file1> <file2>`
+- If hooks modify files during commit, re-stage and commit again.
+
 ## Documentation and demos
 
 The official documentation is hosted on [Read the Docs](https://docs.godotengine.org).

--- a/doc/classes/UltimateAIBackendContractAdapter.xml
+++ b/doc/classes/UltimateAIBackendContractAdapter.xml
@@ -49,12 +49,42 @@
 			<description>
 			</description>
 		</method>
+		<method name="list_locks" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="session_id" type="String" default="&quot;&quot;" />
+			<description>
+			</description>
+		</method>
 		<method name="list_tools" qualifiers="const">
 			<return type="Dictionary" />
 			<description>
 			</description>
 		</method>
+		<method name="realtime_join" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="payload" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="realtime_negotiate" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="payload" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="release_lock" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="lock_id" type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="request_task" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="payload" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="send_session_delta" qualifiers="const">
 			<return type="Dictionary" />
 			<param index="0" name="payload" type="Dictionary" />
 			<description>

--- a/modules/ultimate_ai/core/backend_contract_adapter.cpp
+++ b/modules/ultimate_ai/core/backend_contract_adapter.cpp
@@ -33,7 +33,10 @@
 
 #include "backend_contract_adapter.h"
 
+#include "core/config/project_settings.h"
 #include "core/crypto/crypto.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/io/json.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -77,8 +80,12 @@ inline String _normalize_service_mode(const String &p_mode) {
 	return "managed";
 }
 
+inline bool _service_mode_requires_auth_header(const String &p_mode) {
+	return p_mode == "managed" || p_mode == "managed_byok" || p_mode == "byok";
+}
+
 inline bool _allow_env_token_hooks() {
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	return true;
 #else
 	return false;
@@ -86,11 +93,143 @@ inline bool _allow_env_token_hooks() {
 }
 
 inline bool _allow_static_runtime_tokens() {
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	return true;
 #else
 	return false;
 #endif
+}
+
+String _get_env_file_value(const String &p_file_path, const String &p_key) {
+	if (p_file_path.is_empty() || p_key.is_empty() || !FileAccess::exists(p_file_path)) {
+		return String();
+	}
+
+	Ref<FileAccess> env_file = FileAccess::open(p_file_path, FileAccess::READ);
+	if (env_file.is_null()) {
+		return String();
+	}
+
+	while (!env_file->eof_reached()) {
+		String line = env_file->get_line().strip_edges();
+		if (!line.is_empty() && line.unicode_at(0) == 0xFEFF) {
+			line = line.substr(1, line.length() - 1);
+		}
+		if (line.is_empty() || line.begins_with("#")) {
+			continue;
+		}
+
+		int separator = line.find("=");
+		if (separator <= 0) {
+			continue;
+		}
+
+		String key = line.substr(0, separator).strip_edges();
+		if (key != p_key) {
+			continue;
+		}
+
+		String value = line.substr(separator + 1, line.length()).strip_edges();
+		if (value.length() >= 2) {
+			if ((value.begins_with("\"") && value.ends_with("\"")) || (value.begins_with("'") && value.ends_with("'"))) {
+				value = value.substr(1, value.length() - 2);
+			}
+		}
+		return value.strip_edges();
+	}
+
+	return String();
+}
+
+PackedStringArray _collect_env_file_candidates() {
+	PackedStringArray candidates;
+
+	auto append_candidate_dirs = [&](const String &p_dir) {
+		String current = p_dir.simplify_path();
+		for (int depth = 0; depth < 6; depth++) {
+			if (current.is_empty()) {
+				break;
+			}
+
+			String candidate = current.path_join(".env.local").simplify_path();
+			if (!candidate.is_empty() && !candidates.has(candidate)) {
+				candidates.push_back(candidate);
+			}
+
+			String parent = current.get_base_dir().simplify_path();
+			if (parent.is_empty() || parent == current) {
+				break;
+			}
+			current = parent;
+		}
+	};
+
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	if (project_settings) {
+		String project_root = project_settings->globalize_path("res://").simplify_path();
+		append_candidate_dirs(project_root);
+	}
+
+	Ref<DirAccess> current_dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	if (current_dir_access.is_valid()) {
+		String current_dir = current_dir_access->get_current_dir().simplify_path();
+		append_candidate_dirs(current_dir);
+	}
+
+	OS *os = OS::get_singleton();
+	if (os) {
+		String executable_dir = os->get_executable_path().get_base_dir().simplify_path();
+		append_candidate_dirs(executable_dir);
+	}
+
+	PackedStringArray deduped;
+	for (int i = 0; i < candidates.size(); i++) {
+		String candidate = candidates[i].strip_edges();
+		if (candidate.is_empty()) {
+			continue;
+		}
+		if (deduped.has(candidate)) {
+			continue;
+		}
+		deduped.push_back(candidate);
+	}
+
+	return deduped;
+}
+
+String _resolve_gateway_api_token_from_env_sources() {
+	OS *os = OS::get_singleton();
+	if (os) {
+		if (os->has_environment("PHOENIX_API_TOKEN")) {
+			String value = os->get_environment("PHOENIX_API_TOKEN").strip_edges();
+			if (!value.is_empty()) {
+				return value;
+			}
+		}
+		if (os->has_environment("PHOENIX_GATEWAY_API_TOKEN")) {
+			String value = os->get_environment("PHOENIX_GATEWAY_API_TOKEN").strip_edges();
+			if (!value.is_empty()) {
+				return value;
+			}
+		}
+	}
+
+	PackedStringArray candidates = _collect_env_file_candidates();
+	for (int i = 0; i < candidates.size(); i++) {
+		String value = _get_env_file_value(candidates[i], "PHOENIX_API_TOKEN");
+		if (!value.is_empty()) {
+			return value;
+		}
+	}
+
+	for (int i = 0; i < candidates.size(); i++) {
+		String value = _get_env_file_value(candidates[i], "PHOENIX_GATEWAY_API_TOKEN");
+		if (!value.is_empty()) {
+			return value;
+		}
+	}
+
+	return String();
 }
 
 void _apply_default_command_allowlist(PackedStringArray &r_allowlist) {
@@ -140,36 +279,35 @@ String UltimateAIBackendContractAdapter::_generate_request_id(const String &p_pr
 }
 
 String UltimateAIBackendContractAdapter::_resolve_auth_token() const {
-	if (!_allow_static_runtime_tokens()) {
-		return String();
-	}
-
 	String token = runtime_config.token.strip_edges();
 	if (!token.is_empty()) {
 		return token;
 	}
 
 	String hook = runtime_config.token_hook.strip_edges();
-	if (hook.is_empty()) {
+	if (!hook.is_empty()) {
+		if (hook.begins_with("env:")) {
+			if (_allow_env_token_hooks()) {
+				String env_var = hook.substr(4, hook.length()).strip_edges();
+				if (!env_var.is_empty() && OS::get_singleton()->has_environment(env_var)) {
+					String env_value = OS::get_singleton()->get_environment(env_var).strip_edges();
+					if (!env_value.is_empty()) {
+						return env_value;
+					}
+				}
+			}
+		} else {
+			if (_allow_static_runtime_tokens()) {
+				return hook;
+			}
+		}
+	}
+
+	if (_normalize_service_mode(runtime_config.auth_mode) == "offline") {
 		return String();
 	}
 
-	if (hook.begins_with("env:")) {
-		if (!_allow_env_token_hooks()) {
-			return String();
-		}
-
-		String env_var = hook.substr(4, hook.length()).strip_edges();
-		if (env_var.is_empty()) {
-			return String();
-		}
-		if (!OS::get_singleton()->has_environment(env_var)) {
-			return String();
-		}
-		return OS::get_singleton()->get_environment(env_var).strip_edges();
-	}
-
-	return hook;
+	return _resolve_gateway_api_token_from_env_sources();
 }
 
 String UltimateAIBackendContractAdapter::_extract_header_value(const List<String> &p_headers, const String &p_key) const {
@@ -314,8 +452,9 @@ Dictionary UltimateAIBackendContractAdapter::_request_once(HTTPClient::Method p_
 	headers.push_back(String("Content-Type: application/json"));
 	headers.push_back(vformat("%s: %s", HEADER_REQUEST_ID, request_id));
 	headers.push_back(vformat("%s: %s", HEADER_CORRELATION_ID, correlation_id));
-	headers.push_back(vformat("x-phoenix-service-mode: %s", runtime_config.auth_mode));
-	headers.push_back(vformat("x-phoenix-auth-mode: %s", runtime_config.auth_mode));
+	String auth_mode = _normalize_service_mode(runtime_config.auth_mode);
+	headers.push_back(vformat("x-phoenix-service-mode: %s", auth_mode));
+	headers.push_back(vformat("x-phoenix-auth-mode: %s", auth_mode));
 	if (!runtime_config.tier.is_empty()) {
 		headers.push_back(vformat("x-phoenix-tier: %s", runtime_config.tier));
 	}
@@ -324,6 +463,11 @@ Dictionary UltimateAIBackendContractAdapter::_request_once(HTTPClient::Method p_
 	}
 
 	String auth_token = _resolve_auth_token();
+	if (_service_mode_requires_auth_header(auth_mode) && auth_token.is_empty()) {
+		response["transport_error"] = true;
+		response["error"] = "Missing gateway auth token for managed/byok mode. Set PHOENIX_API_TOKEN (or PHOENIX_GATEWAY_API_TOKEN) in the engine environment or in .env.local at the project root.";
+		return response;
+	}
 	if (!auth_token.is_empty()) {
 		headers.push_back(vformat("%s: Bearer %s", HEADER_AUTHORIZATION, auth_token));
 	}

--- a/modules/ultimate_ai/core/backend_contract_adapter.cpp
+++ b/modules/ultimate_ai/core/backend_contract_adapter.cpp
@@ -129,7 +129,9 @@ String _get_env_file_value(const String &p_file_path, const String &p_key) {
 			continue;
 		}
 
-		String value = line.substr(separator + 1, line.length()).strip_edges();
+		int value_start = separator + 1;
+		int value_len = line.length() - value_start;
+		String value = line.substr(value_start, value_len).strip_edges();
 		if (value.length() >= 2) {
 			if ((value.begins_with("\"") && value.ends_with("\"")) || (value.begins_with("'") && value.ends_with("'"))) {
 				value = value.substr(1, value.length() - 2);
@@ -280,7 +282,7 @@ String UltimateAIBackendContractAdapter::_generate_request_id(const String &p_pr
 
 String UltimateAIBackendContractAdapter::_resolve_auth_token() const {
 	String token = runtime_config.token.strip_edges();
-	if (!token.is_empty()) {
+	if (!token.is_empty() && _allow_static_runtime_tokens()) {
 		return token;
 	}
 
@@ -304,6 +306,10 @@ String UltimateAIBackendContractAdapter::_resolve_auth_token() const {
 	}
 
 	if (_normalize_service_mode(runtime_config.auth_mode) == "offline") {
+		return String();
+	}
+
+	if (!_allow_env_token_hooks()) {
 		return String();
 	}
 
@@ -465,7 +471,7 @@ Dictionary UltimateAIBackendContractAdapter::_request_once(HTTPClient::Method p_
 	String auth_token = _resolve_auth_token();
 	if (_service_mode_requires_auth_header(auth_mode) && auth_token.is_empty()) {
 		response["transport_error"] = true;
-		response["error"] = "Missing gateway auth token for managed/byok mode. Set PHOENIX_API_TOKEN (or PHOENIX_GATEWAY_API_TOKEN) in the engine environment or in .env.local at the project root.";
+		response["error"] = "Missing gateway auth token for managed/byok mode. Set PHOENIX_API_TOKEN (or PHOENIX_GATEWAY_API_TOKEN) in the engine environment or in a discoverable .env.local near the project/editor/executable working directories.";
 		return response;
 	}
 	if (!auth_token.is_empty()) {

--- a/modules/ultimate_ai/scripts/build_docs_image.py
+++ b/modules/ultimate_ai/scripts/build_docs_image.py
@@ -24,7 +24,9 @@ def _run_command(args: list[str], *, check: bool = True) -> subprocess.Completed
 
     if check and result.returncode != 0:
         stderr = (result.stderr or "").strip()
-        raise CommandError(f"Command failed ({' '.join(args)}): {stderr}")
+        stdout = (result.stdout or "").strip()
+        message = stderr or stdout or "Unknown command failure"
+        raise CommandError(f"Command failed ({' '.join(args)}): {message}")
 
     return result
 
@@ -92,58 +94,63 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    root = _engine_root()
-    submodule_dir = root / SUBMODULE_REL_PATH
-    dockerfile = root / DOCKERFILE_REL_PATH
-    marker_path = root / MARKER_REL_PATH
+    try:
+        root = _engine_root()
+        submodule_dir = root / SUBMODULE_REL_PATH
+        dockerfile = root / DOCKERFILE_REL_PATH
+        marker_path = root / MARKER_REL_PATH
 
-    if not submodule_dir.exists():
-        print(f"Submodule path not found: {submodule_dir}", file=sys.stderr)
-        return 1
-    if not dockerfile.exists():
-        print(f"Dockerfile not found: {dockerfile}", file=sys.stderr)
-        return 1
+        if not submodule_dir.exists():
+            print(f"Submodule path not found: {submodule_dir}", file=sys.stderr)
+            return 1
+        if not dockerfile.exists():
+            print(f"Dockerfile not found: {dockerfile}", file=sys.stderr)
+            return 1
 
-    current_sha = _submodule_sha(submodule_dir)
-    stored_sha = _read_marker(marker_path)
-    sha_changed = stored_sha != current_sha
+        current_sha = _submodule_sha(submodule_dir)
+        stored_sha = _read_marker(marker_path)
+        sha_changed = stored_sha != current_sha
 
-    print(f"Submodule SHA: {current_sha}")
-    if stored_sha:
-        print(f"Marker SHA:    {stored_sha}")
-    else:
-        print("Marker SHA:    <missing>")
-
-    if args.dry_run:
-        print("Dry-run enabled: skipping Docker availability/daemon/image checks.")
-        image_exists = False
-    else:
-        _docker_available()
-        _docker_daemon_running()
-        image_exists = _image_exists(IMAGE_TAG)
-
-    reasons: list[str] = []
-    if args.force_rebuild:
-        reasons.append("forced")
-    if not image_exists:
-        reasons.append("image missing")
-    if sha_changed:
-        reasons.append("submodule SHA changed")
-
-    should_rebuild = len(reasons) > 0
-
-    if should_rebuild:
-        print(f"Rebuild required ({', '.join(reasons)}).")
-        if args.dry_run:
-            print(f"Dry-run: would execute: docker build -f {dockerfile} -t {IMAGE_TAG} {submodule_dir}")
+        print(f"Submodule SHA: {current_sha}")
+        if stored_sha:
+            print(f"Marker SHA:    {stored_sha}")
         else:
-            _build_image(dockerfile, submodule_dir, IMAGE_TAG)
-        _write_marker(marker_path, current_sha)
-        print(f"Updated marker: {marker_path}")
-    else:
-        print("Image is up-to-date; no rebuild required.")
+            print("Marker SHA:    <missing>")
 
-    return 0
+        if args.dry_run:
+            print("Dry-run enabled: skipping Docker availability/daemon/image checks.")
+            image_exists = bool(stored_sha) and not sha_changed
+        else:
+            _docker_available()
+            _docker_daemon_running()
+            image_exists = _image_exists(IMAGE_TAG)
+
+        reasons: list[str] = []
+        if args.force_rebuild:
+            reasons.append("forced")
+        if not image_exists:
+            reasons.append("image missing")
+        if sha_changed:
+            reasons.append("submodule SHA changed")
+
+        should_rebuild = len(reasons) > 0
+
+        if should_rebuild:
+            print(f"Rebuild required ({', '.join(reasons)}).")
+            if args.dry_run:
+                print(f"Dry-run: would execute: docker build -f {dockerfile} -t {IMAGE_TAG} {submodule_dir}")
+                print("Dry-run: marker file was not modified.")
+            else:
+                _build_image(dockerfile, submodule_dir, IMAGE_TAG)
+                _write_marker(marker_path, current_sha)
+                print(f"Updated marker: {marker_path}")
+        else:
+            print("Image is up-to-date; no rebuild required.")
+
+        return 0
+    except CommandError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/modules/ultimate_ai/scripts/build_docs_image.py
+++ b/modules/ultimate_ai/scripts/build_docs_image.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+IMAGE_TAG = "godot-mcp-docs:local"
+SUBMODULE_REL_PATH = Path("modules/ultimate_ai/external/godot-mcp-docs")
+DOCKERFILE_REL_PATH = SUBMODULE_REL_PATH / "deploy" / "Dockerfile"
+MARKER_REL_PATH = Path("modules/ultimate_ai/.phoenix_docs_image_revision")
+
+
+class CommandError(RuntimeError):
+    pass
+
+
+def _run_command(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(args, check=False, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise CommandError(f"Command not found: {args[0]}") from exc
+
+    if check and result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise CommandError(f"Command failed ({' '.join(args)}): {stderr}")
+
+    return result
+
+
+def _engine_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _submodule_sha(submodule_dir: Path) -> str:
+    result = _run_command(["git", "-C", str(submodule_dir), "rev-parse", "HEAD"])
+    return result.stdout.strip()
+
+
+def _read_marker(marker_path: Path) -> str:
+    if not marker_path.exists():
+        return ""
+    return marker_path.read_text(encoding="utf-8").strip()
+
+
+def _write_marker(marker_path: Path, sha: str) -> None:
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text(f"{sha}\n", encoding="utf-8")
+
+
+def _docker_available() -> None:
+    _run_command(["docker", "--version"])
+
+
+def _docker_daemon_running() -> None:
+    _run_command(["docker", "info"])
+
+
+def _image_exists(tag: str) -> bool:
+    result = _run_command(["docker", "image", "inspect", tag], check=False)
+    return result.returncode == 0
+
+
+def _build_image(dockerfile: Path, context_dir: Path, tag: str) -> None:
+    _run_command(
+        [
+            "docker",
+            "build",
+            "-f",
+            str(dockerfile),
+            "-t",
+            tag,
+            str(context_dir),
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build/refresh local godot-mcp-docs Docker image using submodule SHA marker."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip Docker checks/build and simulate build logic (CI-safe without Docker).",
+    )
+    parser.add_argument(
+        "--force-rebuild",
+        action="store_true",
+        help="Force rebuild regardless of image/marker status.",
+    )
+    args = parser.parse_args()
+
+    root = _engine_root()
+    submodule_dir = root / SUBMODULE_REL_PATH
+    dockerfile = root / DOCKERFILE_REL_PATH
+    marker_path = root / MARKER_REL_PATH
+
+    if not submodule_dir.exists():
+        print(f"Submodule path not found: {submodule_dir}", file=sys.stderr)
+        return 1
+    if not dockerfile.exists():
+        print(f"Dockerfile not found: {dockerfile}", file=sys.stderr)
+        return 1
+
+    current_sha = _submodule_sha(submodule_dir)
+    stored_sha = _read_marker(marker_path)
+    sha_changed = stored_sha != current_sha
+
+    print(f"Submodule SHA: {current_sha}")
+    if stored_sha:
+        print(f"Marker SHA:    {stored_sha}")
+    else:
+        print("Marker SHA:    <missing>")
+
+    if args.dry_run:
+        print("Dry-run enabled: skipping Docker availability/daemon/image checks.")
+        image_exists = False
+    else:
+        _docker_available()
+        _docker_daemon_running()
+        image_exists = _image_exists(IMAGE_TAG)
+
+    reasons: list[str] = []
+    if args.force_rebuild:
+        reasons.append("forced")
+    if not image_exists:
+        reasons.append("image missing")
+    if sha_changed:
+        reasons.append("submodule SHA changed")
+
+    should_rebuild = len(reasons) > 0
+
+    if should_rebuild:
+        print(f"Rebuild required ({', '.join(reasons)}).")
+        if args.dry_run:
+            print(f"Dry-run: would execute: docker build -f {dockerfile} -t {IMAGE_TAG} {submodule_dir}")
+        else:
+            _build_image(dockerfile, submodule_dir, IMAGE_TAG)
+        _write_marker(marker_path, current_sha)
+        print(f"Updated marker: {marker_path}")
+    else:
+        print("Image is up-to-date; no rebuild required.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/ultimate_ai/ui/assistant_panel.cpp
+++ b/modules/ultimate_ai/ui/assistant_panel.cpp
@@ -202,7 +202,7 @@ bool _is_allowed_help_topic(const String &p_topic) {
 
 	for (int i = 0; i < topic.length(); i++) {
 		char32_t character = topic[i];
-		if (_is_ascii_identifier_char(character) || character == ':') {
+		if (_is_ascii_identifier_char(character) || character == ':' || character == '@') {
 			continue;
 		}
 		return false;
@@ -1732,6 +1732,31 @@ void UltimateAssistantPanel::_append_message(int p_tab_id, const String &p_role,
 		return;
 	}
 	_clear_loading_chat_indicator_for_tab(p_tab_id);
+	if (tab.command_stream_active) {
+		String incoming_role_key = safe_role.to_lower();
+		if (incoming_role_key.is_empty()) {
+			incoming_role_key = "assistant";
+		}
+
+		String stream_role_key = tab.command_stream_role.strip_edges().to_lower();
+		if (stream_role_key.is_empty()) {
+			stream_role_key = "assistant";
+		}
+
+		if (incoming_role_key != stream_role_key) {
+			if (!tab.command_stream_remaining.is_empty()) {
+				String remaining = tab.command_stream_remaining;
+				tab.command_stream_remaining.clear();
+				_append_stream_delta_for_tab(p_tab_id, tab.command_stream_role, remaining, true);
+			} else if (tab.assistant_stream_open) {
+				_append_stream_delta_for_tab(p_tab_id, String(), String(), true);
+			}
+
+			tab.command_stream_active = false;
+			tab.command_stream_role.clear();
+			tab.next_command_stream_tick_msec = 0;
+		}
+	}
 	if (tab.assistant_stream_open) {
 		_append_stream_delta_for_tab(p_tab_id, String(), String(), true);
 		tab.assistant_stream_from_realtime = false;
@@ -3828,7 +3853,10 @@ void UltimateAssistantPanel::_execute_single_command(int p_tab_id, const Diction
 			}
 		}
 
-		_extract_docs_candidates_from_text(query, class_candidates);
+		const bool has_explicit_class_candidates = !class_candidates.is_empty();
+		if (!has_explicit_class_candidates) {
+			_extract_docs_candidates_from_text(query, class_candidates);
+		}
 
 		String resolved_class_name;
 		for (int i = 0; i < class_candidates.size(); i++) {
@@ -3839,10 +3867,6 @@ void UltimateAssistantPanel::_execute_single_command(int p_tab_id, const Diction
 			}
 		}
 
-		if (resolved_class_name.is_empty() && !class_candidates.is_empty()) {
-			resolved_class_name = class_candidates[0];
-		}
-
 		if (!resolved_class_name.is_empty()) {
 			script_editor->goto_help("class:" + resolved_class_name);
 			_append_message(p_tab_id, TTR("System"), vformat("Opened in-editor docs for class: %s", resolved_class_name));
@@ -3850,7 +3874,13 @@ void UltimateAssistantPanel::_execute_single_command(int p_tab_id, const Diction
 		}
 
 		String topic = String(p_command.get("topic", String())).strip_edges();
-		if (topic.is_empty() && _is_allowed_help_topic(query)) {
+		if (topic.is_empty()) {
+			String raw_class_name = String(p_command.get("class_name", String())).strip_edges();
+			if (raw_class_name.begins_with("@")) {
+				topic = "class_name:" + raw_class_name;
+			}
+		}
+		if (topic.is_empty() && !has_explicit_class_candidates && _is_allowed_help_topic(query)) {
 			topic = query;
 		}
 

--- a/modules/ultimate_ai/ui/assistant_panel.cpp
+++ b/modules/ultimate_ai/ui/assistant_panel.cpp
@@ -3877,7 +3877,10 @@ void UltimateAssistantPanel::_execute_single_command(int p_tab_id, const Diction
 		if (topic.is_empty()) {
 			String raw_class_name = String(p_command.get("class_name", String())).strip_edges();
 			if (raw_class_name.begins_with("@")) {
-				topic = "class_name:" + raw_class_name;
+				String normalized_class_name = raw_class_name.substr(1, raw_class_name.length() - 1).strip_edges();
+				if (!normalized_class_name.is_empty()) {
+					topic = "class_name:" + normalized_class_name;
+				}
 			}
 		}
 		if (topic.is_empty() && !has_explicit_class_candidates && _is_allowed_help_topic(query)) {

--- a/modules/ultimate_ai/ui/assistant_settings_dialog.cpp
+++ b/modules/ultimate_ai/ui/assistant_settings_dialog.cpp
@@ -92,7 +92,7 @@ bool _service_mode_uses_byok_credentials(const String &p_mode) {
 }
 
 bool _allow_env_token_resolution() {
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	return true;
 #else
 	return false;
@@ -100,7 +100,7 @@ bool _allow_env_token_resolution() {
 }
 
 bool _allow_static_gateway_token_overrides() {
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	return true;
 #else
 	return false;

--- a/scripts/validate-editor-headless.ps1
+++ b/scripts/validate-editor-headless.ps1
@@ -1,0 +1,95 @@
+param(
+    [ValidateSet("version", "startup", "doctool-temp", "all", "all-full")]
+    [string]$Action = "all"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $repoRoot
+
+function Resolve-EditorBinary {
+    $candidates = @(
+        ".\\bin\\phoenix_agentic.windows.editor.dev.x86_64.console.exe",
+        ".\\bin\\phoenix_agentic.windows.editor.x86_64.console.exe",
+        ".\\bin\\phoenix_agentic.windows.editor.dev.x86_64.exe",
+        ".\\bin\\phoenix_agentic.windows.editor.x86_64.exe"
+    )
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+
+    throw "No Phoenix editor binary found under .\\bin. Run task 'dev: build editor' first."
+}
+
+function Invoke-EditorCheck {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [string]$EditorBinary,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    Write-Host ("Running {0}: {1} {2}" -f $Name, $EditorBinary, ($Arguments -join " ")) -ForegroundColor Cyan
+    & $EditorBinary @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw ("{0} failed with exit code {1}." -f $Name, $LASTEXITCODE)
+    }
+}
+
+$editorBinary = Resolve-EditorBinary
+
+switch ($Action) {
+    "version" {
+        Invoke-EditorCheck -Name "headless version" -EditorBinary $editorBinary -Arguments @("--headless", "--version")
+    }
+    "startup" {
+        Invoke-EditorCheck -Name "headless startup" -EditorBinary $editorBinary -Arguments @("--headless", "--quit")
+    }
+    "doctool-temp" {
+        $doctoolOutDir = Join-Path $env:TEMP "phoenix-doctool-smoke"
+        if (Test-Path $doctoolOutDir) {
+            Remove-Item -Path $doctoolOutDir -Recurse -Force
+        }
+        New-Item -ItemType Directory -Path $doctoolOutDir -Force | Out-Null
+
+        try {
+            Invoke-EditorCheck -Name "doctool headless" -EditorBinary $editorBinary -Arguments @("--doctool", $doctoolOutDir, "--headless")
+        }
+        finally {
+            if (Test-Path $doctoolOutDir) {
+                Remove-Item -Path $doctoolOutDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+    "all" {
+        Invoke-EditorCheck -Name "headless version" -EditorBinary $editorBinary -Arguments @("--headless", "--version")
+        Invoke-EditorCheck -Name "headless startup" -EditorBinary $editorBinary -Arguments @("--headless", "--quit")
+    }
+    "all-full" {
+        Invoke-EditorCheck -Name "headless version" -EditorBinary $editorBinary -Arguments @("--headless", "--version")
+        Invoke-EditorCheck -Name "headless startup" -EditorBinary $editorBinary -Arguments @("--headless", "--quit")
+
+        $doctoolOutDir = Join-Path $env:TEMP "phoenix-doctool-smoke"
+        if (Test-Path $doctoolOutDir) {
+            Remove-Item -Path $doctoolOutDir -Recurse -Force
+        }
+        New-Item -ItemType Directory -Path $doctoolOutDir -Force | Out-Null
+
+        try {
+            Invoke-EditorCheck -Name "doctool headless" -EditorBinary $editorBinary -Arguments @("--doctool", $doctoolOutDir, "--headless")
+        }
+        finally {
+            if (Test-Path $doctoolOutDir) {
+                Remove-Item -Path $doctoolOutDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
+
+Write-Host "Validation task completed successfully." -ForegroundColor Green


### PR DESCRIPTION
## Summary
This PR now includes two change sets on `mcp-docs/pr0-submodule`:

1. **godot-mcp-docs submodule + docs image build script**
   - add `modules/ultimate_ai/external/godot-mcp-docs`
   - pin to `579a06ff79d71a53308d806a58da0b9faaa5edc7`
   - add `modules/ultimate_ai/scripts/build_docs_image.py` for local image management (`godot-mcp-docs:local`) with SHA marker behavior

2. **Workflow hygiene / docs / instructions / skills updates (plus staged pending engine edits)**
   - update contributor and instruction docs for terminal-first git hygiene, pre-commit gating, PR workflow checks, and CI failure triage
   - update skill files to require MCP-based PR ops, Copilot review handling, test/pre-commit validation, and GitHub Actions checks during PRs
   - include staged pending edits in:
     - `modules/ultimate_ai/core/backend_contract_adapter.cpp`
     - `modules/ultimate_ai/ui/assistant_panel.cpp`
     - `modules/ultimate_ai/ui/assistant_settings_dialog.cpp`
     - `.github/workflows/web_builds.yml`
     - `.gitignore`

## Validation performed
- local pre-commit checks passed for updated docs/instructions/skills files
- commit hook suite passed during commit
- branch pushed and PR updated

## PR hygiene status
- Base branch: `feature/agent-backend-integration`
- Head branch: `mcp-docs/pr0-submodule`
- GitHub Actions currently running for latest head commit