### PR TITLE
chore: remove delete-signal-labels option from sync workflow

### DIFF
--- a/.github/workflows/sync-project-fields.yml
+++ b/.github/workflows/sync-project-fields.yml
@@ -28,7 +28,6 @@ on:
         type: choice
         options:
           - create-signal-labels
-          - delete-signal-labels
 
 env:
   PROJECT_NUMBER: 3
@@ -81,20 +80,6 @@ jobs:
                 }
               }
               core.info('All signal labels created.');
-            } else if (action === 'delete-signal-labels') {
-              for (const label of SIGNAL_LABELS) {
-                try {
-                  await github.rest.issues.deleteLabel({ owner, repo, name: label.name });
-                  core.info(`Deleted label: ${label.name}`);
-                } catch (e) {
-                  if (e.status === 404) {
-                    core.info(`Label not found: ${label.name}`);
-                  } else {
-                    core.warning(`Failed to delete ${label.name}: ${e.message}`);
-                  }
-                }
-              }
-              core.info('All signal labels deleted.');
             }
 
   # ── Main: sync a signal label to a project field ───────────────────


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
